### PR TITLE
Tune down the INFO logging, use debug log level where sensible

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStreamFactory.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStreamFactory.java
@@ -216,16 +216,16 @@ public final class DecryptionStreamFactory {
             }
 
             if (verificationKey == null) {
-                LOGGER.log(Level.INFO, "No public key for signature of " + Long.toHexString(keyId) + " found.");
+                LOGGER.log(Level.FINER, "No public key for signature of " + Long.toHexString(keyId) + " found.");
 
                 if (missingPublicKeyCallback == null) {
-                    LOGGER.log(Level.INFO, "Skip signature of " + Long.toHexString(keyId));
+                    LOGGER.log(Level.FINER, "Skip signature of " + Long.toHexString(keyId));
                     continue;
                 }
 
                 PGPPublicKey missingPublicKey = missingPublicKeyCallback.onMissingPublicKeyEncountered(keyId);
                 if (missingPublicKey == null) {
-                    LOGGER.log(Level.INFO, "Skip signature of " + Long.toHexString(keyId));
+                    LOGGER.log(Level.FINER, "Skip signature of " + Long.toHexString(keyId));
                     continue;
                 }
 

--- a/pgpainless-core/src/main/java/org/pgpainless/util/KeyRingSubKeyFix.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/util/KeyRingSubKeyFix.java
@@ -73,7 +73,7 @@ public class KeyRingSubKeyFix {
                 PGPSecretKey secSubKey = secretKeyIterator.next();
 
                 if (secSubKey.isMasterKey()) {
-                    LOGGER.log(Level.INFO, Long.toHexString(secSubKey.getKeyID()) + " is master key. Skip.");
+                    LOGGER.log(Level.FINER, Long.toHexString(secSubKey.getKeyID()) + " is master key. Skip.");
                     _secretKeys.add(secSubKey);
                     continue;
                 }
@@ -93,7 +93,7 @@ public class KeyRingSubKeyFix {
                 }
 
                 // Sub key is normal key -> fix
-                LOGGER.log(Level.INFO, "Subkey " + Long.toHexString(secSubKey.getKeyID()) + " does not have a subkey key packet. Convert it...");
+                LOGGER.log(Level.FINER, "Subkey " + Long.toHexString(secSubKey.getKeyID()) + " does not have a subkey key packet. Convert it...");
                 keyPacket = new PublicSubkeyPacket(pubSubKey.getAlgorithm(), pubSubKey.getCreationTime(), keyPacket.getKey());
                 publicPk.set(pubSubKey, keyPacket);
 

--- a/pgpainless-core/src/test/java/org/pgpainless/BCUtilTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/BCUtilTest.java
@@ -57,22 +57,22 @@ public class BCUtilTest extends AbstractPGPainlessTest {
         PGPSecretKeyRing sec = ring.getSecretKeys();
         PGPPublicKeyRing pub = ring.getPublicKeys();
 
-        LOGGER.log(Level.INFO, "Main ID: " + sec.getPublicKey().getKeyID() + " " + pub.getPublicKey().getKeyID());
+        LOGGER.log(Level.FINER, "Main ID: " + sec.getPublicKey().getKeyID() + " " + pub.getPublicKey().getKeyID());
 
         int secSize = 1;
         Iterator<PGPPublicKey> secPubIt = sec.getPublicKeys();
         while (secPubIt.hasNext()) {
             PGPPublicKey k = secPubIt.next();
-            LOGGER.log(Level.INFO, secSize + " " + k.getKeyID() + " " + k.isEncryptionKey() + " " + k.isMasterKey());
+            LOGGER.log(Level.FINER, secSize + " " + k.getKeyID() + " " + k.isEncryptionKey() + " " + k.isMasterKey());
             secSize++;
         }
 
-        LOGGER.log(Level.INFO, "After BCUtil.publicKeyRingFromSecretKeyRing()");
+        LOGGER.log(Level.FINER, "After BCUtil.publicKeyRingFromSecretKeyRing()");
         int pubSize = 1;
         Iterator<PGPPublicKey> pubPubIt = pub.getPublicKeys();
         while (pubPubIt.hasNext()) {
             PGPPublicKey k = pubPubIt.next();
-            LOGGER.log(Level.INFO, pubSize + " " + k.getKeyID() + " " + k.isEncryptionKey() + " " + k.isMasterKey());
+            LOGGER.log(Level.FINER, pubSize + " " + k.getKeyID() + " " + k.isEncryptionKey() + " " + k.isMasterKey());
             pubSize++;
         }
 
@@ -84,11 +84,11 @@ public class BCUtilTest extends AbstractPGPainlessTest {
         Iterator<PGPSecretKeyRing> secColIt = secCol.getKeyRings();
         while (secColIt.hasNext()) {
             PGPSecretKeyRing r = secColIt.next();
-            LOGGER.log(Level.INFO, "" + r.getPublicKey().getKeyID());
+            LOGGER.log(Level.FINER, "" + r.getPublicKey().getKeyID());
             secColSize++;
         }
 
-        LOGGER.log(Level.INFO, "SecCol: " + secColSize);
+        LOGGER.log(Level.FINER, "SecCol: " + secColSize);
 
         PGPPublicKeyRingCollection pubCol = BCUtil.keyRingsToKeyRingCollection(pub);
 
@@ -96,11 +96,11 @@ public class BCUtilTest extends AbstractPGPainlessTest {
         Iterator<PGPPublicKeyRing> pubColIt = pubCol.getKeyRings();
         while (pubColIt.hasNext()) {
             PGPPublicKeyRing r = pubColIt.next();
-            LOGGER.log(Level.INFO, "" + r.getPublicKey().getKeyID());
+            LOGGER.log(Level.FINER, "" + r.getPublicKey().getKeyID());
             pubColSize++;
         }
 
-        LOGGER.log(Level.INFO, "PubCol: " + pubColSize);
+        LOGGER.log(Level.FINER, "PubCol: " + pubColSize);
     }
 
     @Test

--- a/pgpainless-core/src/test/java/org/pgpainless/LengthTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/LengthTest.java
@@ -47,7 +47,7 @@ public class LengthTest extends AbstractPGPainlessTest {
     public void ecEc()
             throws PGPException, NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException,
             IOException {
-        LOGGER.log(Level.INFO, "\nEC -> EC");
+        LOGGER.log(Level.FINER, "\nEC -> EC");
         PGPKeyRing sender = PGPainless.generateKeyRing().simpleEcKeyRing("simplejid@server.tld");
         PGPKeyRing recipient = PGPainless.generateKeyRing().simpleEcKeyRing("otherjid@other.srv");
         encryptDecryptForSecretKeyRings(sender, recipient);
@@ -58,7 +58,7 @@ public class LengthTest extends AbstractPGPainlessTest {
     public void RsaRsa()
             throws PGPException, NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException,
             IOException {
-        LOGGER.log(Level.INFO, "\nRSA-2048 -> RSA-2048");
+        LOGGER.log(Level.FINER, "\nRSA-2048 -> RSA-2048");
         @SuppressWarnings("deprecation")
         PGPKeyRing sender = PGPainless.generateKeyRing().simpleRsaKeyRing("simplejid@server.tld", RsaLength._2048);
         @SuppressWarnings("deprecation")
@@ -70,7 +70,7 @@ public class LengthTest extends AbstractPGPainlessTest {
     public void RsaRsa4096()
             throws PGPException,
             IOException {
-        LOGGER.log(Level.INFO, "\nRSA-4096 -> RSA-4096");
+        LOGGER.log(Level.FINER, "\nRSA-4096 -> RSA-4096");
         PGPKeyRing sender = PGPainless.readKeyRing().keyRing(TestKeys.JULIET_PUB, TestKeys.JULIET_SEC);
         PGPKeyRing recipient = PGPainless.readKeyRing().keyRing(TestKeys.ROMEO_PUB, TestKeys.ROMEO_SEC);
         encryptDecryptForSecretKeyRings(sender, recipient);
@@ -79,7 +79,7 @@ public class LengthTest extends AbstractPGPainlessTest {
     // @Test
     public void rsaEc() throws PGPException, IOException, InvalidAlgorithmParameterException, NoSuchAlgorithmException,
             NoSuchProviderException {
-        LOGGER.log(Level.INFO, "\nRSA-2048 -> EC");
+        LOGGER.log(Level.FINER, "\nRSA-2048 -> EC");
         @SuppressWarnings("deprecation")
         PGPKeyRing sender = PGPainless.generateKeyRing().simpleRsaKeyRing("simplejid@server.tld", RsaLength._2048);
         PGPKeyRing recipient = PGPainless.generateKeyRing().simpleEcKeyRing("otherjid@other.srv");
@@ -90,7 +90,7 @@ public class LengthTest extends AbstractPGPainlessTest {
     public void ecRsa()
             throws PGPException, NoSuchAlgorithmException, NoSuchProviderException, InvalidAlgorithmParameterException,
             IOException {
-        LOGGER.log(Level.INFO, "\nEC -> RSA-2048");
+        LOGGER.log(Level.FINER, "\nEC -> RSA-2048");
         PGPKeyRing sender = PGPainless.generateKeyRing().simpleEcKeyRing("simplejid@server.tld");
         @SuppressWarnings("deprecation")
         PGPKeyRing recipient = PGPainless.generateKeyRing().simpleRsaKeyRing("otherjid@other.srv", RsaLength._2048);
@@ -126,7 +126,7 @@ public class LengthTest extends AbstractPGPainlessTest {
             encryptor.close();
             byte[] encryptedSecretMessage = envelope.toByteArray();
 
-            LOGGER.log(Level.INFO,"\n" + encryptedSecretMessage.length);
+            LOGGER.log(Level.FINER,"\n" + encryptedSecretMessage.length);
         }
     }
 }


### PR DESCRIPTION
Libraries should usually stay silent if everything works as
expected. Most of the INFO log levels call sites of pgpainless
actually are more of debug log level call sites. Hence this commit
changes most of them to use a debug log level.

I personally would also consider remove some of the log call sites now.