### PR TITLE
gradle: fix missing Maven POM 'description' value

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ subprojects {
                 artifact testsJar
                 pom {
                     name = 'PGPainless'
-                    description 'Simple to use OpenPGP API for Java based on Bouncycastle'
+                    description = 'Simple to use OpenPGP API for Java based on Bouncycastle'
                     url = 'https://github.com/pgpainless/pgpainless'
                     inceptionYear = '2018'
 


### PR DESCRIPTION
With the maven-publish plugin, description needs to be assigned, not
called.