### PR TITLE
Fix creating keys with `Passphrase.emptyPassphrase()`

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/key/generation/KeyRingBuilder.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/generation/KeyRingBuilder.java
@@ -338,7 +338,7 @@ public class KeyRingBuilder implements KeyRingBuilderInterface {
             }
 
             private PBESecretKeyEncryptor buildSecretKeyEncryptor() {
-                PBESecretKeyEncryptor encryptor = passphrase == null ?
+                PBESecretKeyEncryptor encryptor = passphrase == null || passphrase.isEmpty() ?
                         null : // unencrypted key pair, otherwise AES-256 encrypted
                         new JcePBESecretKeyEncryptorBuilder(PGPEncryptedData.AES_256, digestCalculator)
                                 .setProvider(ProviderFactory.getProvider())
@@ -347,7 +347,7 @@ public class KeyRingBuilder implements KeyRingBuilderInterface {
             }
 
             private PBESecretKeyDecryptor buildSecretKeyDecryptor() throws PGPException {
-                PBESecretKeyDecryptor decryptor = passphrase == null ?
+                PBESecretKeyDecryptor decryptor = passphrase == null || passphrase.isEmpty() ?
                         null :
                         new JcePBESecretKeyDecryptorBuilder()
                         .build(passphrase.getChars());

--- a/pgpainless-core/src/main/java/org/pgpainless/util/Passphrase.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/util/Passphrase.java
@@ -92,6 +92,17 @@ public class Passphrase {
     }
 
     /**
+     * Return true if the passphrase represents no password.
+     *
+     * @return empty
+     */
+    public boolean isEmpty() {
+        synchronized (lock) {
+            return chars == null;
+        }
+    }
+
+    /**
      * Represents a {@link Passphrase} instance that represents no password.
      *
      * @return empty passphrase

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateWithEmptyPassphrase.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateWithEmptyPassphrase.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pgpainless.key.generation;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Iterator;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.junit.Test;
+import org.pgpainless.PGPainless;
+import org.pgpainless.key.generation.type.RSA;
+import org.pgpainless.key.generation.type.length.RsaLength;
+import org.pgpainless.util.Passphrase;
+
+public class GenerateWithEmptyPassphrase {
+
+    @Test
+    public void test() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, PGPException, IOException {
+        assertNotNull(PGPainless.generateKeyRing()
+                .withMasterKey(KeySpec.getBuilder(RSA.withLength(RsaLength._3072))
+                        .withDefaultKeyFlags()
+                        .withDefaultAlgorithms())
+                .withPrimaryUserId("primary@user.id")
+                .withPassphrase(Passphrase.emptyPassphrase())
+                .build());
+    }
+}


### PR DESCRIPTION
Previously the code supplied `null` to BouncyCastle's encryptor/decryptor builder's build method and that caused
NullPointerException to be thrown.

The fix checks if the passphrase is empty and omits the BouncyCastle builder in that case.

Fixes #16.