### PR TITLE
Add ability to modify expiration dates for keys

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/key/modification/secretkeyring/SecretKeyRingEditorInterface.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/modification/secretkeyring/SecretKeyRingEditorInterface.java
@@ -15,6 +15,7 @@
  */
 package org.pgpainless.key.modification.secretkeyring;
 
+import java.util.Date;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import javax.annotation.Nonnull;
@@ -187,6 +188,19 @@ public interface SecretKeyRingEditorInterface {
     SecretKeyRingEditorInterface revokeSubKey(long subKeyId,
                                               SecretKeyRingProtector secretKeyRingProtector,
                                               RevocationAttributes revocationAttributes)
+            throws PGPException;
+
+    /**
+     * Set key expiration time.
+     *
+     * @param fingerprint key that will have its expiration date adjusted
+     * @param expiration target expiration time or @{code null} for no expiration
+     * @param secretKeyRingProtector protector to unlock the priary key
+     * @return the builder
+     */
+    SecretKeyRingEditorInterface setExpirationDate(OpenPgpV4Fingerprint fingerprint,
+                                                   Date expiration,
+                                                   SecretKeyRingProtector secretKeyRingProtector)
             throws PGPException;
 
     /**

--- a/pgpainless-core/src/test/java/org/pgpainless/key/modification/ChangeExpirationTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/modification/ChangeExpirationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pgpainless.key.modification;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.junit.jupiter.api.Test;
+import org.pgpainless.PGPainless;
+import org.pgpainless.key.OpenPgpV4Fingerprint;
+import org.pgpainless.key.TestKeys;
+import org.pgpainless.key.info.KeyRingInfo;
+import org.pgpainless.key.protection.UnprotectedKeysProtector;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ChangeExpirationTest {
+
+    @Test
+    public void setExpirationDateAndThenUnsetIt() throws PGPException, IOException, InterruptedException {
+        PGPSecretKeyRing secretKeys = TestKeys.getEmilSecretKeyRing();
+
+        KeyRingInfo sInfo = PGPainless.inspectKeyRing(secretKeys);
+        OpenPgpV4Fingerprint fingerprint = sInfo.getFingerprint();
+
+        assertNull(sInfo.getExpirationDate());
+
+        Date date = new Date(1606493432000L);
+        secretKeys = PGPainless.modifyKeyRing(secretKeys).setExpirationDate(fingerprint, date, new UnprotectedKeysProtector()).done();
+        sInfo = PGPainless.inspectKeyRing(secretKeys);
+        assertNotNull(sInfo.getExpirationDate());
+        assertEquals(date.getTime(), sInfo.getExpirationDate().getTime());
+
+        // We need to wait for one second as OpenPGP signatures have coarse-grained (up to a second)
+        // accuracy. Creating two signatures within a short amount of time will make the second one
+        // "invisible"
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys).setExpirationDate(fingerprint, null, new UnprotectedKeysProtector()).done();
+        sInfo = PGPainless.inspectKeyRing(secretKeys);
+        assertNull(sInfo.getExpirationDate());
+    }
+}


### PR DESCRIPTION
Take a look at it @vanitasvitae I just hacked it together :+1: 

I see quite a lot of common code in these functions and I wonder if it'd be possible to somehow refactor it.

There is also the `if (secretKeyIterator.hasNext()) {`, replacing that with `while` and attempting to change all secret keys fails. It seems the same keys are in the iterator, is that possible?

I'm also setting the key expiration for all users to mimic what GnuPG does.

Does adding new certification copy old values too? It'd be bad if setting expiration on a key cleared for example algorithm preferences, etc. :)