### PR TITLE
Modified Passphrase.fromPassword() to fit Kotlin needs

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/util/Passphrase.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/util/Passphrase.java
@@ -15,6 +15,7 @@
  */
 package org.pgpainless.util;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 
@@ -37,11 +38,11 @@ public class Passphrase {
     /**
      * Create a {@link Passphrase} from a {@link String}.
      *
-     * @param password password that may be null
+     * @param password password
      * @return passphrase
      */
-    public static Passphrase fromPassword(@Nullable String password) {
-        return new Passphrase(password == null ? null : password.toCharArray());
+    public static Passphrase fromPassword(@Nonnull String password) {
+        return new Passphrase(password.toCharArray());
     }
 
     /**

--- a/pgpainless-core/src/main/java/org/pgpainless/util/Passphrase.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/util/Passphrase.java
@@ -37,11 +37,11 @@ public class Passphrase {
     /**
      * Create a {@link Passphrase} from a {@link String}.
      *
-     * @param password password
+     * @param password password that may be null
      * @return passphrase
      */
-    public static Passphrase fromPassword(String password) {
-        return new Passphrase(password.toCharArray());
+    public static Passphrase fromPassword(@Nullable String password) {
+        return new Passphrase(password == null ? null : password.toCharArray());
     }
 
     /**

--- a/pgpainless-core/src/test/java/org/pgpainless/key/protection/PassphraseTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/protection/PassphraseTest.java
@@ -37,4 +37,11 @@ public class PassphraseTest {
         assertFalse(passphrase.isValid());
         assertThrows(IllegalStateException.class, passphrase::getChars);
     }
+
+    @Test
+    public void testFromPasswordNull() {
+        Passphrase passphrase = Passphrase.fromPassword(null);
+        assertArrayEquals(null, passphrase.getChars());
+        assertTrue(passphrase.isValid());
+    }
 }

--- a/pgpainless-core/src/test/java/org/pgpainless/key/protection/PassphraseTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/protection/PassphraseTest.java
@@ -37,11 +37,4 @@ public class PassphraseTest {
         assertFalse(passphrase.isValid());
         assertThrows(IllegalStateException.class, passphrase::getChars);
     }
-
-    @Test
-    public void testFromPasswordNull() {
-        Passphrase passphrase = Passphrase.fromPassword(null);
-        assertArrayEquals(null, passphrase.getChars());
-        assertTrue(passphrase.isValid());
-    }
 }


### PR DESCRIPTION
As described in the code below a source for `Passphrase` may be null for empty passwords

https://github.com/pgpainless/pgpainless/blob/cd19f91d77eb566ede20f82f26dd33c5755a5ef6/pgpainless-core/src/main/java/org/pgpainless/util/Passphrase.java#L33

Additionally, we have the following

```
/**
     * Create a {@link Passphrase} from a {@link String}.
     *
     * @param password password
     * @return passphrase
     */
    public static Passphrase fromPassword(String password) {
        return new Passphrase(password.toCharArray());
    }
```

Using it as is in `Kotlin` throws `NullPointerException`

![image](https://user-images.githubusercontent.com/2863246/114009631-fb4d4580-986b-11eb-992c-e5f08794df7b.png)

I think it'll be better to add `@Nonnull` to `Passphrase.fromPassword()` if we expect a non-null value or apply my changes to use any value.