### PR TITLE
Make builds reproducible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -178,26 +178,6 @@ subprojects {
         required { signingRequired }
         sign publishing.publications.mavenJava
     }
-
-    def generatedVersionDir = "${buildDir}/generated-version"
-
-    sourceSets {
-        main {
-            output.dir(generatedVersionDir, builtBy: 'generateVersionProperties')
-        }
-    }
-
-    task generateVersionProperties {
-        doLast {
-            def propertiesFile = file "$generatedVersionDir/version.properties"
-            propertiesFile.parentFile.mkdirs()
-            propertiesFile.createNewFile()
-            // Instead of using a Properties object here, we directly write to the file
-            //  since Properties adds a timestamp, ruining reproducibility
-            propertiesFile.write("version="+rootProject.version.toString())
-        }
-    }
-    processResources.dependsOn generateVersionProperties
 }
 
 def getGitCommit() {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import java.text.SimpleDateFormat
-
 buildscript {
 
     repositories {
@@ -55,11 +53,16 @@ allprojects {
         mavenCentral()
     }
 
+    // Reproducible Builds
+    tasks.withType(AbstractArchiveTask) {
+        preserveFileTimestamps = false
+        reproducibleFileOrder = true
+    }
+
     project.ext {
         junitVersion = '5.7.1'
         rootConfigDir = new File(rootDir, 'config')
         gitCommit = getGitCommit()
-        builtDate = (new SimpleDateFormat("yyyy-MM-dd")).format(new Date())
         isContinuousIntegrationEnvironment = Boolean.parseBoolean(System.getenv('CI'))
         isReleaseVersion = !isSnapshot
         signingRequired = !(isSnapshot || isContinuousIntegrationEnvironment)
@@ -188,9 +191,10 @@ subprojects {
         doLast {
             def propertiesFile = file "$generatedVersionDir/version.properties"
             propertiesFile.parentFile.mkdirs()
-            def properties = new Properties()
-            properties.setProperty("version", rootProject.version.toString())
-            propertiesFile.withWriter { properties.store(it, null) }
+            propertiesFile.createNewFile()
+            // Instead of using a Properties object here, we directly write to the file
+            //  since Properties adds a timestamp, ruining reproducibility
+            propertiesFile.write("version="+rootProject.version.toString())
         }
     }
     processResources.dependsOn generateVersionProperties

--- a/pgpainless-sop/build.gradle
+++ b/pgpainless-sop/build.gradle
@@ -23,6 +23,26 @@ dependencies {
 
 mainClassName = 'org.pgpainless.sop.PGPainlessCLI'
 
+def generatedVersionDir = "${buildDir}/generated-version"
+
+sourceSets {
+    main {
+        output.dir(generatedVersionDir, builtBy: 'generateVersionProperties')
+    }
+}
+
+task generateVersionProperties {
+    doLast {
+        def propertiesFile = file "$generatedVersionDir/version.properties"
+        propertiesFile.parentFile.mkdirs()
+        propertiesFile.createNewFile()
+        // Instead of using a Properties object here, we directly write to the file
+        //  since Properties adds a timestamp, ruining reproducibility
+        propertiesFile.write("version="+rootProject.version.toString())
+    }
+}
+processResources.dependsOn generateVersionProperties
+
 jar {
     manifest {
         attributes 'Main-Class': "$mainClassName"


### PR DESCRIPTION
Having reproducible builds improves on security, since downstream can verify that the published binary has not been tampered with and has in fact been generated from the source.