### PR TITLE
Switch from JUL logging to SLF4J

### DIFF
--- a/pgpainless-core/build.gradle
+++ b/pgpainless-core/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
     api "org.bouncycastle:bcpg-jdk15on:$bouncyCastleVersion"
 
+    implementation 'org.slf4j:slf4j-api:1.7.32'
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
+
     // https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
 }

--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStream.java
@@ -20,8 +20,6 @@ import static org.pgpainless.signature.SignatureValidator.signatureWasCreatedInB
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
@@ -31,6 +29,8 @@ import org.pgpainless.signature.DetachedSignature;
 import org.pgpainless.signature.CertificateValidator;
 import org.pgpainless.exception.SignatureValidationException;
 import org.pgpainless.util.IntegrityProtectedInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Decryption Stream that handles updating and verification of detached signatures,
@@ -38,7 +38,7 @@ import org.pgpainless.util.IntegrityProtectedInputStream;
  */
 public class DecryptionStream extends InputStream {
 
-    private static final Logger LOGGER = Logger.getLogger(DecryptionStream.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(DecryptionStream.class);
 
     private final InputStream inputStream;
     private final ConsumerOptions options;
@@ -108,7 +108,7 @@ public class DecryptionStream extends InputStream {
                 boolean verified = CertificateValidator.validateCertificateAndVerifyInitializedSignature(s.getSignature(), (PGPPublicKeyRing) s.getSigningKeyRing(), PGPainless.getPolicy());
                 s.setVerified(verified);
             } catch (SignatureValidationException e) {
-                LOGGER.log(Level.WARNING, "Could not verify signature of key " + s.getSigningKeyIdentifier(), e);
+                LOGGER.warn("Could not verify signature of key {}", s.getSigningKeyIdentifier(), e);
             }
         }
     }

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionBuilder.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionBuilder.java
@@ -28,8 +28,12 @@ import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
 import org.pgpainless.algorithm.negotiation.SymmetricKeyAlgorithmNegotiator;
 import org.pgpainless.key.SubkeyIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class EncryptionBuilder implements EncryptionBuilderInterface {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionBuilder.class);
 
     private OutputStream outputStream;
 
@@ -61,12 +65,14 @@ public class EncryptionBuilder implements EncryptionBuilderInterface {
             preferences.add(encryptionOptions.getKeyViews().get(key).getPreferredSymmetricKeyAlgorithms());
         }
 
-        return SymmetricKeyAlgorithmNegotiator
+        SymmetricKeyAlgorithm algorithm = SymmetricKeyAlgorithmNegotiator
                 .byPopularity()
                 .negotiate(
                         PGPainless.getPolicy().getSymmetricKeyEncryptionAlgorithmPolicy(),
                         encryptionOptions.getEncryptionAlgorithmOverride(),
                         preferences);
+        LOGGER.debug("Negotiation resulted in {} being the symmetric encryption algorithm of choice.", algorithm);
+        return algorithm;
     }
 
     public static CompressionAlgorithm negotiateCompressionAlgorithm(ProducerOptions producerOptions) {

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 
 import org.bouncycastle.bcpg.ArmoredOutputStream;
@@ -38,6 +36,8 @@ import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
 import org.pgpainless.implementation.ImplementationFactory;
 import org.pgpainless.key.SubkeyIdentifier;
 import org.pgpainless.util.ArmoredOutputStreamFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is based upon Jens Neuhalfen's Bouncy-GPG PGPEncryptingStream.
@@ -45,8 +45,7 @@ import org.pgpainless.util.ArmoredOutputStreamFactory;
  */
 public final class EncryptionStream extends OutputStream {
 
-    private static final Logger LOGGER = Logger.getLogger(EncryptionStream.class.getName());
-    private static final Level LEVEL = Level.FINE;
+    private static final Logger LOGGER = LoggerFactory.getLogger(EncryptionStream.class);
 
     private final ProducerOptions options;
     private final EncryptionResult.Builder resultBuilder = EncryptionResult.builder();
@@ -80,11 +79,11 @@ public final class EncryptionStream extends OutputStream {
 
     private void prepareArmor() {
         if (!options.isAsciiArmor()) {
-            LOGGER.log(LEVEL, "Encryption output will be binary");
+            LOGGER.debug("Output will be unarmored");
             return;
         }
 
-        LOGGER.log(LEVEL, "Wrap encryption output in ASCII armor");
+        LOGGER.debug("Wrap encryption output in ASCII armor");
         armorOutputStream = ArmoredOutputStreamFactory.get(outermostStream);
         outermostStream = armorOutputStream;
     }
@@ -99,7 +98,7 @@ public final class EncryptionStream extends OutputStream {
 
         SymmetricKeyAlgorithm encryptionAlgorithm = EncryptionBuilder.negotiateSymmetricEncryptionAlgorithm(encryptionOptions);
         resultBuilder.setEncryptionAlgorithm(encryptionAlgorithm);
-        LOGGER.log(LEVEL, "Encrypt message using {}", encryptionAlgorithm);
+        LOGGER.debug("Encrypt message using {}", encryptionAlgorithm);
         PGPDataEncryptorBuilder dataEncryptorBuilder =
                 ImplementationFactory.getInstance().getPGPDataEncryptorBuilder(encryptionAlgorithm);
         dataEncryptorBuilder.setWithIntegrityPacket(true);
@@ -127,7 +126,7 @@ public final class EncryptionStream extends OutputStream {
             return;
         }
 
-        LOGGER.log(LEVEL, "Compress using {}", compressionAlgorithm);
+        LOGGER.debug("Compress using {}", compressionAlgorithm);
         basicCompressionStream = new BCPGOutputStream(compressedDataGenerator.open(outermostStream));
         outermostStream = basicCompressionStream;
     }

--- a/pgpainless-core/src/main/java/org/pgpainless/key/KeyRingValidator.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/KeyRingValidator.java
@@ -19,8 +19,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPKeyRing;
@@ -35,6 +33,8 @@ import org.pgpainless.policy.Policy;
 import org.pgpainless.signature.SignatureCreationDateComparator;
 import org.pgpainless.signature.SignatureVerifier;
 import org.pgpainless.util.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class KeyRingValidator {
 
@@ -42,7 +42,7 @@ public final class KeyRingValidator {
 
     }
 
-    private static final Logger LOGGER = Logger.getLogger(KeyRingValidator.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(KeyRingValidator.class);
 
     public static <R extends PGPKeyRing> R validate(R keyRing, Policy policy) {
         try {
@@ -81,7 +81,7 @@ public final class KeyRingValidator {
                     blank = PGPPublicKey.addCertification(blank, signature);
                 }
             } catch (SignatureValidationException e) {
-                LOGGER.log(Level.INFO, "Rejecting direct key signature", e);
+                LOGGER.debug("Rejecting direct key signature: {}", e.getMessage(), e);
             }
         }
 
@@ -94,7 +94,7 @@ public final class KeyRingValidator {
                     blank = PGPPublicKey.addCertification(blank, signature);
                 }
             } catch (SignatureValidationException e) {
-                LOGGER.log(Level.INFO, "Rejecting key revocation signature", e);
+                LOGGER.debug("Rejecting key revocation signature: {}", e.getMessage(), e);
             }
         }
 
@@ -116,7 +116,7 @@ public final class KeyRingValidator {
                         }
                     }
                 } catch (SignatureValidationException e) {
-                    LOGGER.log(Level.FINE, "Rejecting user-id certification for user-id " + userId, e);
+                    LOGGER.debug("Rejecting user-id certification for user-id {}: {}", userId, e.getMessage(), e);
                 }
             }
         }
@@ -138,7 +138,7 @@ public final class KeyRingValidator {
                         }
                     }
                 } catch (SignatureValidationException e) {
-                    LOGGER.log(Level.INFO, "Rejecting user-attribute signature", e);
+                    LOGGER.debug("Rejecting user-attribute signature: {}", e.getMessage(), e);
                 }
             }
         }

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/CertificateValidator.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/CertificateValidator.java
@@ -25,8 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.SignerUserID;
@@ -38,6 +36,8 @@ import org.pgpainless.algorithm.SignatureType;
 import org.pgpainless.exception.SignatureValidationException;
 import org.pgpainless.policy.Policy;
 import org.pgpainless.signature.subpackets.SignatureSubpacketsUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A collection of static methods that validate signing certificates (public keys) and verify signature correctness.
@@ -48,7 +48,7 @@ public final class CertificateValidator {
 
     }
 
-    private static final Logger LOGGER = Logger.getLogger(CertificateValidator.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(CertificateValidator.class);
 
     /**
      * Check if the signing key was eligible to create the provided signature.
@@ -88,7 +88,7 @@ public final class CertificateValidator {
                 }
             } catch (SignatureValidationException e) {
                 rejections.put(revocation, e);
-                LOGGER.log(Level.FINE, "Rejecting key revocation signature.", e);
+                LOGGER.debug("Rejecting key revocation signature: {}", e.getMessage(), e);
             }
         }
 
@@ -102,7 +102,7 @@ public final class CertificateValidator {
                 }
             } catch (SignatureValidationException e) {
                 rejections.put(keySignature, e);
-                LOGGER.log(Level.FINE, "Rejecting key signature.", e);
+                LOGGER.debug("Rejecting key signature: {}", e.getMessage(), e);
             }
         }
 
@@ -128,7 +128,7 @@ public final class CertificateValidator {
                     }
                 } catch (SignatureValidationException e) {
                     rejections.put(userIdSig, e);
-                    LOGGER.log(Level.FINE, "Rejecting user-id signature.", e);
+                    LOGGER.debug("Rejecting user-id signature: {}", e.getMessage(), e);
                 }
             }
             Collections.sort(signaturesOnUserId, new SignatureValidityComparator(SignatureCreationDateComparator.Order.NEW_TO_OLD));
@@ -140,7 +140,7 @@ public final class CertificateValidator {
             if (!userIdSignatures.get(userId).isEmpty()) {
                 PGPSignature current = userIdSignatures.get(userId).get(0);
                 if (current.getSignatureType() == SignatureType.CERTIFICATION_REVOCATION.getCode()) {
-                    LOGGER.log(Level.FINE, "User-ID '{}' is revoked.", userId);
+                    LOGGER.debug("User-ID '{}' is revoked.", userId);
                 } else {
                     anyUserIdValid = true;
                 }
@@ -178,7 +178,7 @@ public final class CertificateValidator {
                     }
                 } catch (SignatureValidationException e) {
                     rejections.put(revocation, e);
-                    LOGGER.log(Level.FINE, "Rejecting subkey revocation signature.", e);
+                    LOGGER.debug("Rejecting subkey revocation signature: {}", e.getMessage(), e);
                 }
             }
 
@@ -191,7 +191,7 @@ public final class CertificateValidator {
                     }
                 } catch (SignatureValidationException e) {
                     rejections.put(bindingSig, e);
-                    LOGGER.log(Level.FINE, "Rejecting subkey binding signature.", e);
+                    LOGGER.debug("Rejecting subkey binding signature: {}", e.getMessage(), e);
                 }
             }
 

--- a/pgpainless-core/src/test/java/org/pgpainless/util/BCUtilTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/util/BCUtilTest.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Iterator;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKey;
@@ -37,10 +35,12 @@ import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
 import org.pgpainless.key.util.KeyRingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BCUtilTest {
 
-    private static final Logger LOGGER = Logger.getLogger(BCUtil.class.getName());
+    private static final Logger LOGGER = LoggerFactory.getLogger(BCUtilTest.class);
 
     @Test
     public void keyRingToCollectionTest()
@@ -57,22 +57,22 @@ public class BCUtilTest {
 
         PGPPublicKeyRing pub = KeyRingUtils.publicKeyRingFrom(sec);
 
-        LOGGER.log(Level.FINER, "Main ID: " + sec.getPublicKey().getKeyID() + " " + pub.getPublicKey().getKeyID());
+        assertEquals(sec.getPublicKey().getKeyID(), pub.getPublicKey().getKeyID());
 
         int secSize = 1;
         Iterator<PGPPublicKey> secPubIt = sec.getPublicKeys();
         while (secPubIt.hasNext()) {
             PGPPublicKey k = secPubIt.next();
-            LOGGER.log(Level.FINER, secSize + " " + k.getKeyID() + " " + k.isEncryptionKey() + " " + k.isMasterKey());
+            LOGGER.debug("Index {}, keyId {}, isEncryptionKey={}, isPrimary={}", secSize, k.getKeyID(), k.isEncryptionKey(), k.isMasterKey());
             secSize++;
         }
 
-        LOGGER.log(Level.FINER, "After BCUtil.publicKeyRingFromSecretKeyRing()");
+        LOGGER.debug("After BCUtil.publicKeyRingFromSecretKeyRing()");
         int pubSize = 1;
         Iterator<PGPPublicKey> pubPubIt = pub.getPublicKeys();
         while (pubPubIt.hasNext()) {
             PGPPublicKey k = pubPubIt.next();
-            LOGGER.log(Level.FINER, pubSize + " " + k.getKeyID() + " " + k.isEncryptionKey() + " " + k.isMasterKey());
+            LOGGER.debug("Index {}, keyId {}, isEncryptionKey={}, isPrimary={}", pubSize, k.getKeyID(), k.isEncryptionKey(), k.isMasterKey());
             pubSize++;
         }
 
@@ -84,11 +84,9 @@ public class BCUtilTest {
         Iterator<PGPSecretKeyRing> secColIt = secCol.getKeyRings();
         while (secColIt.hasNext()) {
             PGPSecretKeyRing r = secColIt.next();
-            LOGGER.log(Level.FINER, "" + r.getPublicKey().getKeyID());
+            LOGGER.debug("{}", r.getPublicKey().getKeyID());
             secColSize++;
         }
-
-        LOGGER.log(Level.FINER, "SecCol: " + secColSize);
 
         PGPPublicKeyRingCollection pubCol = KeyRingUtils.keyRingsToKeyRingCollection(pub);
 
@@ -96,10 +94,10 @@ public class BCUtilTest {
         Iterator<PGPPublicKeyRing> pubColIt = pubCol.getKeyRings();
         while (pubColIt.hasNext()) {
             PGPPublicKeyRing r = pubColIt.next();
-            LOGGER.log(Level.FINER, "" + r.getPublicKey().getKeyID());
+            LOGGER.debug("{}", r.getPublicKey().getKeyID());
             pubColSize++;
         }
 
-        LOGGER.log(Level.FINER, "PubCol: " + pubColSize);
+        assertEquals(pubColSize, secColSize);
     }
 }


### PR DESCRIPTION
Since we are a library, it doesn't make sense to hard depend on the JUL logger.
By using SLF4J instead, the consumer of the library can decide the logging framework.

For internal testing we choose logback.

TODO: Figure out whether it makes sense to use SLF4J for console output in sop-java-picocli.
That way we could hide all that ugly stderr output from sop-java-picocli's exit code tests.