### PR TITLE
Adopt changes from the Stateless OpenPGP Protocol specification version 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 out/
 build/
 bin/
+libs/
 
 *.iws
 *.iml

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ allprojects {
     }
 
     project.ext {
+        slf4jVersion = '1.7.32'
         junitVersion = '5.7.2'
         rootConfigDir = new File(rootDir, 'config')
         gitCommit = getGitCommit()

--- a/pgpainless-cli/build.gradle
+++ b/pgpainless-cli/build.gradle
@@ -36,6 +36,8 @@ dependencies {
     // https://todd.ginsberg.com/post/testing-system-exit/
     testImplementation 'com.ginsberg:junit5-system-exit:1.1.1'
 
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
+
     /*
     implementation "org.bouncycastle:bcprov-debug-jdk15on:$bouncyCastleVersion"
     /*/

--- a/pgpainless-cli/build.gradle
+++ b/pgpainless-cli/build.gradle
@@ -36,7 +36,11 @@ dependencies {
     // https://todd.ginsberg.com/post/testing-system-exit/
     testImplementation 'com.ginsberg:junit5-system-exit:1.1.1'
 
+    // We want logback logging in tests
     testImplementation 'ch.qos.logback:logback-classic:1.2.5'
+
+    // We don't want logging in the application itself
+    implementation "org.slf4j:slf4j-nop:$slf4jVersion"
 
     /*
     implementation "org.bouncycastle:bcprov-debug-jdk15on:$bouncyCastleVersion"

--- a/pgpainless-cli/src/main/resources/logback.xml
+++ b/pgpainless-cli/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%blue(%-5level) %green(%logger{35}) - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache" level="INFO ">
+        <appender-ref ref="STDERR"/>
+    </logger>
+</configuration>

--- a/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/ArmorTest.java
+++ b/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/ArmorTest.java
@@ -16,8 +16,6 @@
 package org.pgpainless.cli.commands;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -101,43 +99,4 @@ public class ArmorTest {
         assertTrue(armored.contains("SGVsbG8sIFdvcmxkIQo="));
     }
 
-    @Test
-    @FailOnSystemExit
-    public void doesNotNestArmorByDefault() {
-        String armored = "-----BEGIN PGP MESSAGE-----\n" +
-                "Version: BCPG v1.69\n" +
-                "\n" +
-                "SGVsbG8sIFdvcmxkCg==\n" +
-                "=fkLo\n" +
-                "-----END PGP MESSAGE-----";
-
-        System.setIn(new ByteArrayInputStream(armored.getBytes(StandardCharsets.UTF_8)));
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
-        PGPainlessCLI.execute("armor");
-
-        assertEquals(armored, out.toString());
-    }
-
-    @Test
-    @FailOnSystemExit
-    public void testAllowNested() {
-        String armored = "-----BEGIN PGP MESSAGE-----\n" +
-                "Version: BCPG v1.69\n" +
-                "\n" +
-                "SGVsbG8sIFdvcmxkCg==\n" +
-                "=fkLo\n" +
-                "-----END PGP MESSAGE-----";
-
-        System.setIn(new ByteArrayInputStream(armored.getBytes(StandardCharsets.UTF_8)));
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out));
-        PGPainlessCLI.execute("armor", "--allow-nested");
-
-        assertNotEquals(armored, out.toString());
-        assertTrue(out.toString().contains(
-                "LS0tLS1CRUdJTiBQR1AgTUVTU0FHRS0tLS0tClZlcnNpb246IEJDUEcgdjEuNjkK\n" +
-                "ClNHVnNiRzhzSUZkdmNteGtDZz09Cj1ma0xvCi0tLS0tRU5EIFBHUCBNRVNTQUdF\n" +
-                "LS0tLS0="));
-    }
 }

--- a/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/EncryptDecryptTest.java
+++ b/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/EncryptDecryptTest.java
@@ -101,7 +101,6 @@ public class EncryptDecryptTest {
         msgAscOut.close();
 
         File verifyFile = new File(tempDir, "verify.txt");
-        assertTrue(verifyFile.createNewFile());
 
         FileInputStream msgAscIn = new FileInputStream(msgAscFile);
         System.setIn(msgAscIn);

--- a/pgpainless-core/build.gradle
+++ b/pgpainless-core/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     api files("libs/bcpg-jdk18on-1.70-SNAPSHOT.jar")
     // */
 
-    implementation 'org.slf4j:slf4j-api:1.7.32'
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
     testImplementation 'ch.qos.logback:logback-classic:1.2.5'
 
     // https://mvnrepository.com/artifact/com.google.code.findbugs/jsr305

--- a/pgpainless-core/build.gradle
+++ b/pgpainless-core/build.gradle
@@ -8,7 +8,12 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
 
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
+
+    //*
     api "org.bouncycastle:bcpg-jdk15on:$bouncyCastleVersion"
+    /*/
+    api files("libs/bcpg-jdk18on-1.70-SNAPSHOT.jar")
+    // */
 
     implementation 'org.slf4j:slf4j-api:1.7.32'
     testImplementation 'ch.qos.logback:logback-classic:1.2.5'

--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStreamFactory.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStreamFactory.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 
 import org.bouncycastle.bcpg.ArmoredInputStream;
@@ -88,8 +89,11 @@ public final class DecryptionStreamFactory {
 
     public DecryptionStreamFactory(ConsumerOptions options) {
         this.options = options;
+        initializeDetachedSignatures(options.getDetachedSignatures());
+    }
 
-        for (PGPSignature signature : options.getDetachedSignatures()) {
+    private void initializeDetachedSignatures(Set<PGPSignature> signatures) {
+        for (PGPSignature signature : signatures) {
             long issuerKeyId = SignatureUtils.determineIssuerKeyId(signature);
             PGPPublicKeyRing signingKeyRing = findSignatureVerificationKeyRing(issuerKeyId);
             if (signingKeyRing == null) {

--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStreamFactory.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/DecryptionStreamFactory.java
@@ -134,11 +134,13 @@ public final class DecryptionStreamFactory {
             // Not an OpenPGP message.
             //  Reset the buffered stream to parse the message as arbitrary binary data
             //  to allow for detached signature verification.
+            LOGGER.debug("The message appears to not be an OpenPGP message. This is probably data signed with detached signatures?");
             bufferedIn.reset();
             inputStream = bufferedIn;
         } catch (IOException e) {
             if (e.getMessage().contains("invalid armor")) {
                 // We falsely assumed the data to be armored.
+                LOGGER.debug("The message is apparently not armored.");
                 bufferedIn.reset();
                 inputStream = bufferedIn;
             } else {

--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMetadata.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMetadata.java
@@ -146,16 +146,6 @@ public class OpenPgpMetadata {
         return false;
     }
 
-    public static class Signature {
-        protected final PGPSignature signature;
-        protected final OpenPgpV4Fingerprint fingerprint;
-
-        public Signature(PGPSignature signature, OpenPgpV4Fingerprint fingerprint) {
-            this.signature = signature;
-            this.fingerprint = fingerprint;
-        }
-    }
-
     /**
      * Return the name of the encrypted / signed file.
      *

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/cleartext_signatures/ClearsignedMessageUtil.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/cleartext_signatures/ClearsignedMessageUtil.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2021 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pgpainless.signature.cleartext_signatures;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.bouncycastle.bcpg.ArmoredInputStream;
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPObjectFactory;
+import org.bouncycastle.openpgp.PGPPublicKey;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.PGPSignatureGenerator;
+import org.bouncycastle.openpgp.PGPSignatureList;
+import org.bouncycastle.util.Strings;
+import org.pgpainless.implementation.ImplementationFactory;
+import org.pgpainless.util.ArmoredInputStreamFactory;
+
+/**
+ * Utility class to deal with cleartext-signed messages.
+ * Based on Bouncycastle's {@link org.bouncycastle.openpgp.examples.ClearSignedFileProcessor}.
+ */
+public final class ClearsignedMessageUtil {
+
+    private ClearsignedMessageUtil() {
+
+    }
+
+    /**
+     * Dearmor a clearsigned message, detach the inband signatures and write the plaintext message to the provided
+     * messageOutputStream.
+     *
+     * @param clearsignedInputStream input stream containing a clearsigned message
+     * @param messageOutputStream output stream to which the dearmored message shall be written
+     * @return signatures
+     * @throws IOException if the message is not clearsigned or some other IO error happens
+     */
+    public static PGPSignatureList detachSignaturesFromInbandClearsignedMessage(InputStream clearsignedInputStream,
+                                                                                OutputStream messageOutputStream)
+            throws IOException {
+        ArmoredInputStream in = ArmoredInputStreamFactory.get(clearsignedInputStream);
+        if (!in.isClearText()) {
+            throw new IOException("Message is not clearsigned.");
+        }
+
+        OutputStream out = new BufferedOutputStream(messageOutputStream);
+        try {
+            ByteArrayOutputStream lineOut = new ByteArrayOutputStream();
+            int lookAhead = readInputLine(lineOut, in);
+            byte[] lineSep = getLineSeparator();
+
+            if (lookAhead != -1 && in.isClearText()) {
+                byte[] line = lineOut.toByteArray();
+                out.write(line, 0, getLengthWithoutSeparatorOrTrailingWhitespace(line));
+                out.write(lineSep);
+
+                while (lookAhead != -1 && in.isClearText()) {
+                    lookAhead = readInputLine(lineOut, lookAhead, in);
+                    line = lineOut.toByteArray();
+                    out.write(line, 0, getLengthWithoutSeparatorOrTrailingWhitespace(line));
+                    out.write(lineSep);
+                }
+            } else {
+                if (lookAhead != -1) {
+                    byte[] line = lineOut.toByteArray();
+                    out.write(line, 0, getLengthWithoutSeparatorOrTrailingWhitespace(line));
+                    out.write(lineSep);
+                }
+            }
+        } finally {
+            out.close();
+        }
+
+        PGPObjectFactory objectFactory = new PGPObjectFactory(in, ImplementationFactory.getInstance().getKeyFingerprintCalculator());
+        PGPSignatureList signatures = (PGPSignatureList) objectFactory.nextObject();
+
+        return signatures;
+    }
+
+    /**
+     * Initialize the given signature by processing the data from the messageData input stream.
+     *
+     * @param signature uninitialized signature
+     * @param signingKey public signing key
+     * @param messageData input stream containing the data to which the signature belongs
+     * @return initialized signature
+     *
+     * @throws PGPException if the signature cannot be initialized
+     * @throws IOException if an IO error happens
+     */
+    public static PGPSignature initializeSignature(PGPSignature signature, PGPPublicKey signingKey, InputStream messageData)
+            throws PGPException, IOException {
+        signature.init(ImplementationFactory.getInstance().getPGPContentVerifierBuilderProvider(), signingKey);
+
+        InputStream sigIn = new BufferedInputStream(messageData);
+        ByteArrayOutputStream lineOut = new ByteArrayOutputStream();
+        int lookAhead = readInputLine(lineOut, sigIn);
+        processLine(signature, lineOut.toByteArray());
+
+        if (lookAhead != -1) {
+            do {
+                lookAhead = readInputLine(lineOut, lookAhead, sigIn);
+                signature.update((byte) '\r');
+                signature.update((byte) '\n');
+                processLine(signature, lineOut.toByteArray());
+            } while (lookAhead != -1);
+        }
+        sigIn.close();
+        return signature;
+    }
+
+    public static int readInputLine(ByteArrayOutputStream bOut, InputStream fIn)
+            throws IOException {
+        bOut.reset();
+
+        int lookAhead = -1;
+        int ch;
+
+        while ((ch = fIn.read()) >= 0) {
+            bOut.write(ch);
+            if (ch == '\r' || ch == '\n') {
+                lookAhead = readPassedEOL(bOut, ch, fIn);
+                break;
+            }
+        }
+
+        return lookAhead;
+    }
+
+    public static int readInputLine(ByteArrayOutputStream bOut, int lookAhead, InputStream fIn)
+            throws IOException {
+        bOut.reset();
+
+        int ch = lookAhead;
+
+        do {
+            bOut.write(ch);
+            if (ch == '\r' || ch == '\n') {
+                lookAhead = readPassedEOL(bOut, ch, fIn);
+                break;
+            }
+        }
+        while ((ch = fIn.read()) >= 0);
+
+        if (ch < 0) {
+            lookAhead = -1;
+        }
+
+        return lookAhead;
+    }
+
+    private static int readPassedEOL(ByteArrayOutputStream bOut, int lastCh, InputStream fIn)
+            throws IOException {
+        int lookAhead = fIn.read();
+
+        if (lastCh == '\r' && lookAhead == '\n') {
+            bOut.write(lookAhead);
+            lookAhead = fIn.read();
+        }
+
+        return lookAhead;
+    }
+
+
+    private static byte[] getLineSeparator() {
+        String nl = Strings.lineSeparator();
+        byte[] nlBytes = new byte[nl.length()];
+
+        for (int i = 0; i != nlBytes.length; i++) {
+            nlBytes[i] = (byte) nl.charAt(i);
+        }
+
+        return nlBytes;
+    }
+
+    public static void processLine(PGPSignature sig, byte[] line) {
+        int length = getLengthWithoutWhiteSpace(line);
+        if (length > 0) {
+            sig.update(line, 0, length);
+        }
+    }
+
+    public static void processLine(OutputStream aOut, PGPSignatureGenerator sGen, byte[] line)
+            throws IOException {
+        // note: trailing white space needs to be removed from the end of
+        // each line for signature calculation RFC 4880 Section 7.1
+        int length = getLengthWithoutWhiteSpace(line);
+        if (length > 0) {
+            sGen.update(line, 0, length);
+        }
+
+        aOut.write(line, 0, line.length);
+    }
+
+    private static int getLengthWithoutSeparatorOrTrailingWhitespace(byte[] line) {
+        int    end = line.length - 1;
+
+        while (end >= 0 && isWhiteSpace(line[end])) {
+            end--;
+        }
+
+        return end + 1;
+    }
+
+    private static boolean isLineEnding(byte b) {
+        return b == '\r' || b == '\n';
+    }
+
+    private static int getLengthWithoutWhiteSpace(byte[] line) {
+        int    end = line.length - 1;
+
+        while (end >= 0 && isWhiteSpace(line[end])) {
+            end--;
+        }
+
+        return end + 1;
+    }
+
+    private static boolean isWhiteSpace(byte b) {
+        return isLineEnding(b) || b == '\t' || b == ' ';
+    }
+}

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/cleartext_signatures/CleartextSignatureProcessor.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/cleartext_signatures/CleartextSignatureProcessor.java
@@ -34,6 +34,7 @@ import org.bouncycastle.openpgp.PGPSignatureList;
 import org.pgpainless.PGPainless;
 import org.pgpainless.exception.SignatureValidationException;
 import org.pgpainless.signature.CertificateValidator;
+import org.pgpainless.signature.SignatureVerifier;
 import org.pgpainless.util.ArmoredInputStreamFactory;
 
 /**
@@ -93,7 +94,7 @@ public class CleartextSignatureProcessor {
             }
 
             try {
-                ClearsignedMessageUtil.initializeSignature(signature, signingKey, multiPassStrategy.getMessageInputStream());
+                SignatureVerifier.initializeSignatureAndUpdateWithSignedData(signature, multiPassStrategy.getMessageInputStream(), signingKey);
                 CertificateValidator.validateCertificateAndVerifyInitializedSignature(signature, certificate, PGPainless.getPolicy());
                 return signature;
             } catch (SignatureValidationException e) {

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/cleartext_signatures/MultiPassStrategy.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/cleartext_signatures/MultiPassStrategy.java
@@ -47,6 +47,9 @@ public interface MultiPassStrategy {
      * Provide an {@link InputStream} which contains the data that was previously written away in
      * {@link #getMessageOutputStream()}.
      *
+     * As there may be multiple signatures that need to be processed, each call of this method MUST return
+     * a new {@link InputStream}.
+     *
      * @return input stream
      * @throws IOException io error
      */

--- a/pgpainless-core/src/main/resources/logback.xml
+++ b/pgpainless-core/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.err</target>
+        <encoder>
+            <pattern>%blue(%-5level) %green(%logger{35}) - %msg %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.apache" level="INFO ">
+        <appender-ref ref="STDERR"/>
+    </logger>
+</configuration>

--- a/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/CleartextSignatureVerificationTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/CleartextSignatureVerificationTest.java
@@ -30,7 +30,6 @@ import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPSignature;
 import org.bouncycastle.util.io.Streams;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.pgpainless.PGPainless;
 import org.pgpainless.key.TestKeys;
@@ -125,9 +124,7 @@ public class CleartextSignatureVerificationTest {
         CertificateValidator.validateCertificateAndVerifyInitializedSignature(signature, signingKeys, PGPainless.getPolicy());
     }
 
-    @Test
-    @Disabled
-    public void print() throws IOException {
+    public static void main(String[] args) throws IOException {
         // CHECKSTYLE:OFF
         PGPPublicKeyRing keys = TestKeys.getEmilPublicKeyRing();
         System.out.println(ArmorUtils.toAsciiArmoredString(keys));

--- a/pgpainless-sop/build.gradle
+++ b/pgpainless-sop/build.gradle
@@ -15,6 +15,8 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.7.0'
+
+    testImplementation 'ch.qos.logback:logback-classic:1.2.5'
 }
 
 test {

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/ArmorImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/ArmorImpl.java
@@ -38,7 +38,7 @@ public class ArmorImpl implements Armor {
 
     @Override
     public Armor label(ArmorLabel label) throws SOPGPException.UnsupportedOption {
-        throw new SOPGPException.UnsupportedOption();
+        throw new SOPGPException.UnsupportedOption("Setting custom Armor labels not supported.");
     }
 
     @Override

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/DecryptImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/DecryptImpl.java
@@ -87,7 +87,7 @@ public class DecryptImpl implements Decrypt {
 
     @Override
     public DecryptImpl withSessionKey(SessionKey sessionKey) throws SOPGPException.UnsupportedOption {
-        throw new SOPGPException.UnsupportedOption();
+        throw new SOPGPException.UnsupportedOption("Setting custom session key not supported.");
     }
 
     @Override

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/DecryptImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/DecryptImpl.java
@@ -32,7 +32,6 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.decryption_verification.ConsumerOptions;
 import org.pgpainless.decryption_verification.DecryptionStream;
 import org.pgpainless.decryption_verification.OpenPgpMetadata;
-import org.pgpainless.exception.NotYetImplementedException;
 import org.pgpainless.key.SubkeyIdentifier;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
@@ -50,21 +49,13 @@ public class DecryptImpl implements Decrypt {
 
     @Override
     public DecryptImpl verifyNotBefore(Date timestamp) throws SOPGPException.UnsupportedOption {
-        try {
-            consumerOptions.verifyNotBefore(timestamp);
-        } catch (NotYetImplementedException e) {
-            throw new SOPGPException.UnsupportedOption();
-        }
+        consumerOptions.verifyNotBefore(timestamp);
         return this;
     }
 
     @Override
     public DecryptImpl verifyNotAfter(Date timestamp) throws SOPGPException.UnsupportedOption {
-        try {
-            consumerOptions.verifyNotAfter(timestamp);
-        } catch (NotYetImplementedException e) {
-            throw new SOPGPException.UnsupportedOption();
-        }
+        consumerOptions.verifyNotAfter(timestamp);
         return this;
     }
 

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/DecryptImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/DecryptImpl.java
@@ -104,8 +104,11 @@ public class DecryptImpl implements Decrypt {
     public DecryptImpl withKey(InputStream keyIn) throws SOPGPException.KeyIsProtected, SOPGPException.BadData, SOPGPException.UnsupportedAsymmetricAlgo {
         try {
             PGPSecretKeyRingCollection secretKeys = PGPainless.readKeyRing()
-                    .keyRingCollection(keyIn, true)
-                    .getPGPSecretKeyRingCollection();
+                    .secretKeyRingCollection(keyIn);
+
+            if (secretKeys.size() != 1) {
+                throw new SOPGPException.BadData(new AssertionError("Exactly one single secret key expected. Got " + secretKeys.size()));
+            }
 
             for (PGPSecretKeyRing secretKey : secretKeys) {
                 KeyRingInfo info = new KeyRingInfo(secretKey);

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/DetachInbandSignatureAndMessageImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/DetachInbandSignatureAndMessageImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pgpainless.sop;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.bouncycastle.openpgp.PGPSignatureList;
+import org.pgpainless.signature.cleartext_signatures.ClearsignedMessageUtil;
+import org.pgpainless.util.ArmoredOutputStreamFactory;
+import sop.ReadyWithResult;
+import sop.Signatures;
+import sop.exception.SOPGPException;
+import sop.operation.DetachInbandSignatureAndMessage;
+
+public class DetachInbandSignatureAndMessageImpl implements DetachInbandSignatureAndMessage {
+
+    private boolean armor = true;
+
+    @Override
+    public DetachInbandSignatureAndMessage noArmor() {
+        this.armor = false;
+        return this;
+    }
+
+    @Override
+    public ReadyWithResult<Signatures> message(InputStream messageInputStream) {
+
+        return new ReadyWithResult<Signatures>() {
+            @Override
+            public Signatures writeTo(OutputStream messageOutputStream) throws SOPGPException.NoSignature {
+
+                return new Signatures() {
+                    @Override
+                    public void writeTo(OutputStream signatureOutputStream) throws IOException {
+                        PGPSignatureList signatures = ClearsignedMessageUtil.detachSignaturesFromInbandClearsignedMessage(messageInputStream, messageOutputStream);
+                        if (armor) {
+                            ArmoredOutputStream armorOut = ArmoredOutputStreamFactory.get(signatureOutputStream);
+                            for (PGPSignature signature : signatures) {
+                                signature.encode(armorOut);
+                            }
+                            armorOut.close();
+                        } else {
+                            for (PGPSignature signature : signatures) {
+                                signature.encode(signatureOutputStream);
+                            }
+                        }
+                    }
+                };
+            }
+        };
+    }
+}

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/EncryptImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/EncryptImpl.java
@@ -63,6 +63,9 @@ public class EncryptImpl implements Encrypt {
     public Encrypt signWith(InputStream keyIn) throws SOPGPException.KeyIsProtected, SOPGPException.CertCannotSign, SOPGPException.UnsupportedAsymmetricAlgo, SOPGPException.BadData {
         try {
             PGPSecretKeyRingCollection keys = PGPainless.readKeyRing().secretKeyRingCollection(keyIn);
+            if (keys.size() != 1) {
+                throw new SOPGPException.BadData(new AssertionError("Exactly one secret key at a time expected. Got " + keys.size()));
+            }
 
             if (signingOptions == null) {
                 signingOptions = SigningOptions.get();

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/GenerateKeyImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/GenerateKeyImpl.java
@@ -87,7 +87,7 @@ public class GenerateKeyImpl implements GenerateKey {
                 }
             };
         } catch (InvalidAlgorithmParameterException | NoSuchAlgorithmException e) {
-            throw new SOPGPException.UnsupportedAsymmetricAlgo(e);
+            throw new SOPGPException.UnsupportedAsymmetricAlgo("Unsupported asymmetric algorithm.", e);
         } catch (PGPException e) {
             throw new RuntimeException(e);
         }

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/SOPImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/SOPImpl.java
@@ -19,6 +19,7 @@ import sop.SOP;
 import sop.operation.Armor;
 import sop.operation.Dearmor;
 import sop.operation.Decrypt;
+import sop.operation.DetachInbandSignatureAndMessage;
 import sop.operation.Encrypt;
 import sop.operation.ExtractCert;
 import sop.operation.GenerateKey;
@@ -71,5 +72,10 @@ public class SOPImpl implements SOP {
     @Override
     public Dearmor dearmor() {
         return new DearmorImpl();
+    }
+
+    @Override
+    public DetachInbandSignatureAndMessage detachInbandSignatureAndMessage() {
+        return new DetachInbandSignatureAndMessageImpl();
     }
 }

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/SignImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/SignImpl.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
 import org.bouncycastle.openpgp.PGPSignature;
 import org.bouncycastle.util.io.Streams;
 import org.pgpainless.PGPainless;
@@ -62,7 +63,12 @@ public class SignImpl implements Sign {
     @Override
     public Sign key(InputStream keyIn) throws SOPGPException.KeyIsProtected, SOPGPException.BadData, IOException {
         try {
-            PGPSecretKeyRing key = PGPainless.readKeyRing().secretKeyRing(keyIn);
+            PGPSecretKeyRingCollection keys = PGPainless.readKeyRing().secretKeyRingCollection(keyIn);
+            if (keys.size() != 1) {
+                throw new SOPGPException.BadData(new AssertionError("Exactly one secret key at a time expected. Got " + keys.size()));
+            }
+
+            PGPSecretKeyRing key = keys.iterator().next();
             KeyRingInfo info = new KeyRingInfo(key);
             if (!info.isFullyDecrypted()) {
                 throw new SOPGPException.KeyIsProtected();

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/SignImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/SignImpl.java
@@ -45,8 +45,7 @@ public class SignImpl implements Sign {
 
     private boolean armor = true;
     private SignAs mode = SignAs.Binary;
-    private List<PGPSecretKeyRing> keys = new ArrayList<>();
-    private SigningOptions signingOptions = new SigningOptions();
+    private final SigningOptions signingOptions = new SigningOptions();
 
     @Override
     public Sign noArmor() {

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/VerifyImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/VerifyImpl.java
@@ -29,7 +29,6 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.decryption_verification.ConsumerOptions;
 import org.pgpainless.decryption_verification.DecryptionStream;
 import org.pgpainless.decryption_verification.OpenPgpMetadata;
-import org.pgpainless.exception.NotYetImplementedException;
 import org.pgpainless.key.SubkeyIdentifier;
 import sop.Verification;
 import sop.exception.SOPGPException;
@@ -41,21 +40,13 @@ public class VerifyImpl implements Verify {
 
     @Override
     public Verify notBefore(Date timestamp) throws SOPGPException.UnsupportedOption {
-        try {
-            options.verifyNotBefore(timestamp);
-        } catch (NotYetImplementedException e) {
-            throw new SOPGPException.UnsupportedOption();
-        }
+        options.verifyNotBefore(timestamp);
         return this;
     }
 
     @Override
     public Verify notAfter(Date timestamp) throws SOPGPException.UnsupportedOption {
-        try {
-            options.verifyNotAfter(timestamp);
-        } catch (NotYetImplementedException e) {
-            throw new SOPGPException.UnsupportedOption();
-        }
+        options.verifyNotAfter(timestamp);
         return this;
     }
 

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/FileUtil.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/FileUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sop.cli.picocli;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import sop.exception.SOPGPException;
+
+public class FileUtil {
+
+    private static final String ERROR_AMBIGUOUS = "File name '%s' is ambiguous. File with the same name exists on the filesystem.";
+    private static final String ERROR_ENV_FOUND = "Environment variable '%s' not set.";
+    private static final String ERROR_OUTPUT_EXISTS = "Output file '%s' already exists.";
+    private static final String ERROR_INPUT_NOT_EXIST = "File '%s' does not exist.";
+    private static final String ERROR_CANNOT_CREATE_FILE = "Output file '%s' cannot be created: %s";
+
+    public static final String PRFX_ENV = "@ENV:";
+    public static final String PRFX_FD = "@FD:";
+
+    public static File getFile(String fileName) {
+        if (fileName == null) {
+            throw new NullPointerException("File name cannot be null.");
+        }
+
+        if (fileName.startsWith(PRFX_ENV)) {
+
+            if (new File(fileName).exists()) {
+                throw new SOPGPException.AmbiguousInput(String.format(ERROR_AMBIGUOUS, fileName));
+            }
+
+            String envName = fileName.substring(PRFX_ENV.length());
+            String envValue = System.getenv(envName);
+            if (envValue == null) {
+                throw new IllegalArgumentException(String.format(ERROR_ENV_FOUND, envName));
+            }
+            return new File(envValue);
+        } else if (fileName.startsWith(PRFX_FD)) {
+
+            if (new File(fileName).exists()) {
+                throw new SOPGPException.AmbiguousInput(String.format(ERROR_AMBIGUOUS, fileName));
+            }
+
+            throw new IllegalArgumentException("File descriptors not supported.");
+        }
+
+        return new File(fileName);
+    }
+
+    public static FileInputStream getFileInputStream(String fileName) {
+        File file = getFile(fileName);
+        try {
+            FileInputStream inputStream = new FileInputStream(file);
+            return inputStream;
+        } catch (FileNotFoundException e) {
+            throw new SOPGPException.MissingInput(String.format(ERROR_INPUT_NOT_EXIST, fileName), e);
+        }
+    }
+
+    public static File createNewFileOrThrow(File file) throws IOException {
+        if (file == null) {
+            throw new NullPointerException("File cannot be null.");
+        }
+
+        try {
+            if (!file.createNewFile()) {
+                throw new SOPGPException.OutputExists(String.format(ERROR_OUTPUT_EXISTS, file.getAbsolutePath()));
+            }
+        } catch (IOException e) {
+            throw new IOException(String.format(ERROR_CANNOT_CREATE_FILE, file.getAbsolutePath(), e.getMessage()));
+        }
+        return file;
+    }
+}

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/SOPExceptionExitCodeMapper.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/SOPExceptionExitCodeMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sop.cli.picocli;
+
+import picocli.CommandLine;
+import sop.exception.SOPGPException;
+
+public class SOPExceptionExitCodeMapper implements CommandLine.IExitCodeExceptionMapper {
+
+    @Override
+    public int getExitCode(Throwable exception) {
+        if (exception instanceof SOPGPException) {
+            return ((SOPGPException) exception).getExitCode();
+        }
+        if (exception instanceof CommandLine.UnmatchedArgumentException) {
+            CommandLine.UnmatchedArgumentException ex = (CommandLine.UnmatchedArgumentException) exception;
+            // Unmatched option of subcommand (eg. `generate-key -k`)
+            if (ex.isUnknownOption()) {
+                return SOPGPException.UnsupportedOption.EXIT_CODE;
+            }
+            // Unmatched subcommand
+            return SOPGPException.UnsupportedSubcommand.EXIT_CODE;
+        }
+        // Invalid option (eg. `--label Invalid`)
+        if (exception instanceof CommandLine.ParameterException) {
+            return SOPGPException.UnsupportedOption.EXIT_CODE;
+        }
+
+        // Others, like IOException etc.
+        return 1;
+    }
+}

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/SOPExecutionExceptionHandler.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/SOPExecutionExceptionHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sop.cli.picocli;
+
+import picocli.CommandLine;
+
+public class SOPExecutionExceptionHandler implements CommandLine.IExecutionExceptionHandler {
+
+    @Override
+    public int handleExecutionException(Exception ex, CommandLine commandLine, CommandLine.ParseResult parseResult) throws Exception {
+        int exitCode = commandLine.getExitCodeExceptionMapper() != null ?
+                commandLine.getExitCodeExceptionMapper().getExitCode(ex) :
+                commandLine.getCommandSpec().exitCodeOnExecutionException();
+        CommandLine.Help.ColorScheme colorScheme = commandLine.getColorScheme();
+        // CHECKSTYLE:OFF
+        if (ex.getMessage() != null) {
+            commandLine.getErr().println(colorScheme.errorText(ex.getMessage()));
+        }
+        ex.printStackTrace(commandLine.getErr());
+        // CHECKSTYLE:ON
+
+        return exitCode;
+    }
+}

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/SopCLI.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/SopCLI.java
@@ -58,6 +58,8 @@ public class SopCLI {
     public static int execute(String[] args) {
         return new CommandLine(SopCLI.class)
                 .setCommandName(EXECUTABLE_NAME)
+                .setExecutionExceptionHandler(new SOPExecutionExceptionHandler())
+                .setExitCodeExceptionMapper(new SOPExceptionExitCodeMapper())
                 .setCaseInsensitiveEnumValuesAllowed(true)
                 .execute(args);
     }

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/SopCLI.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/SopCLI.java
@@ -20,6 +20,7 @@ import sop.SOP;
 import sop.cli.picocli.commands.ArmorCmd;
 import sop.cli.picocli.commands.DearmorCmd;
 import sop.cli.picocli.commands.DecryptCmd;
+import sop.cli.picocli.commands.DetachInbandSignatureAndMessageCmd;
 import sop.cli.picocli.commands.EncryptCmd;
 import sop.cli.picocli.commands.ExtractCertCmd;
 import sop.cli.picocli.commands.GenerateKeyCmd;
@@ -34,6 +35,7 @@ import sop.cli.picocli.commands.VersionCmd;
                 ArmorCmd.class,
                 DearmorCmd.class,
                 DecryptCmd.class,
+                DetachInbandSignatureAndMessageCmd.class,
                 EncryptCmd.class,
                 ExtractCertCmd.class,
                 GenerateKeyCmd.class,

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/commands/ArmorCmd.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/commands/ArmorCmd.java
@@ -33,21 +33,9 @@ public class ArmorCmd implements Runnable {
     @CommandLine.Option(names = {"--label"}, description = "Label to be used in the header and tail of the armoring.", paramLabel = "{auto|sig|key|cert|message}")
     ArmorLabel label;
 
-    @CommandLine.Option(names = {"--allow-nested"}, description = "Allow additional armoring of already armored input")
-    boolean allowNested = false;
-
     @Override
     public void run() {
         Armor armor = SopCLI.getSop().armor();
-        if (allowNested) {
-            try {
-                armor.allowNested();
-            } catch (SOPGPException.UnsupportedOption unsupportedOption) {
-                Print.errln("Option --allow-nested is not supported.");
-                Print.trace(unsupportedOption);
-                System.exit(unsupportedOption.getExitCode());
-            }
-        }
         if (label != null) {
             try {
                 armor.label(label);

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/commands/DetachInbandSignatureAndMessageCmd.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/commands/DetachInbandSignatureAndMessageCmd.java
@@ -1,0 +1,11 @@
+package sop.cli.picocli.commands;
+
+import picocli.CommandLine;
+import sop.exception.SOPGPException;
+
+@CommandLine.Command(name = "detach-inband-signature-and-message",
+        description = "Split a clearsigned message",
+        exitCodeOnInvalidInput = SOPGPException.UnsupportedOption.EXIT_CODE)
+public class DetachInbandSignatureAndMessageCmd implements Runnable {
+    
+}

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/commands/DetachInbandSignatureAndMessageCmd.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/commands/DetachInbandSignatureAndMessageCmd.java
@@ -1,11 +1,66 @@
+/*
+ * Copyright 2021 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package sop.cli.picocli.commands;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
 import picocli.CommandLine;
+import sop.Signatures;
+import sop.cli.picocli.SopCLI;
 import sop.exception.SOPGPException;
+import sop.operation.DetachInbandSignatureAndMessage;
 
 @CommandLine.Command(name = "detach-inband-signature-and-message",
         description = "Split a clearsigned message",
         exitCodeOnInvalidInput = SOPGPException.UnsupportedOption.EXIT_CODE)
 public class DetachInbandSignatureAndMessageCmd implements Runnable {
-    
+
+    @CommandLine.Option(
+            names = {"--signatures-out"},
+            description = "Destination to which a detached signatures block will be written",
+            paramLabel = "SIGNATURES")
+    File signaturesOut;
+
+    @CommandLine.Option(names = "--no-armor",
+            description = "ASCII armor the output",
+            negatable = true)
+    boolean armor = true;
+
+    @Override
+    public void run() {
+        if (signaturesOut == null) {
+            throw new SOPGPException.MissingArg("--signatures-out is required.");
+        }
+
+        DetachInbandSignatureAndMessage detach = SopCLI.getSop().detachInbandSignatureAndMessage();
+        if (!armor) {
+            detach.noArmor();
+        }
+
+        try {
+            Signatures signatures = detach
+                    .message(System.in).writeTo(System.out);
+            if (!signaturesOut.createNewFile()) {
+                throw new SOPGPException.OutputExists("Destination of --signatures-out already exists.");
+            }
+            signatures.writeTo(new FileOutputStream(signaturesOut));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/sop-java-picocli/src/main/java/sop/cli/picocli/commands/ExtractCertCmd.java
+++ b/sop-java-picocli/src/main/java/sop/cli/picocli/commands/ExtractCertCmd.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 
 import picocli.CommandLine;
 import sop.Ready;
-import sop.cli.picocli.Print;
 import sop.cli.picocli.SopCLI;
 import sop.exception.SOPGPException;
 import sop.operation.ExtractCert;
@@ -45,13 +44,9 @@ public class ExtractCertCmd implements Runnable {
             Ready ready = extractCert.key(System.in);
             ready.writeTo(System.out);
         } catch (IOException e) {
-            Print.errln("IO Error.");
-            Print.trace(e);
-            System.exit(1);
+            throw new RuntimeException(e);
         } catch (SOPGPException.BadData badData) {
-            Print.errln("Standard Input does not contain valid OpenPGP private key material.");
-            Print.trace(badData);
-            System.exit(badData.getExitCode());
+            throw new SOPGPException.BadData("Standard Input does not contain valid OpenPGP private key material.", badData);
         }
     }
 }

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/ArmorCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/ArmorCmdTest.java
@@ -92,7 +92,7 @@ public class ArmorCmdTest {
     @Test
     @ExpectSystemExitWithStatus(37)
     public void ifLabelsUnsupportedExit37() throws SOPGPException.UnsupportedOption {
-        when(armor.label(any())).thenThrow(new SOPGPException.UnsupportedOption());
+        when(armor.label(any())).thenThrow(new SOPGPException.UnsupportedOption("Custom Armor labels are not supported."));
 
         SopCLI.main(new String[] {"armor", "--label", "Sig"});
     }
@@ -100,7 +100,7 @@ public class ArmorCmdTest {
     @Test
     @ExpectSystemExitWithStatus(37)
     public void ifAllowNestedUnsupportedExit37() throws SOPGPException.UnsupportedOption {
-        when(armor.allowNested()).thenThrow(new SOPGPException.UnsupportedOption());
+        when(armor.allowNested()).thenThrow(new SOPGPException.UnsupportedOption("Allowing nested Armor not supported."));
 
         SopCLI.main(new String[] {"armor", "--allow-nested"});
     }

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/ArmorCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/ArmorCmdTest.java
@@ -52,18 +52,6 @@ public class ArmorCmdTest {
     }
 
     @Test
-    public void assertAllowNestedIsCalledWhenFlagged() throws SOPGPException.UnsupportedOption {
-        SopCLI.main(new String[] {"armor", "--allow-nested"});
-        verify(armor, times(1)).allowNested();
-    }
-
-    @Test
-    public void assertAllowNestedIsNotCalledByDefault() throws SOPGPException.UnsupportedOption {
-        SopCLI.main(new String[] {"armor"});
-        verify(armor, never()).allowNested();
-    }
-
-    @Test
     public void assertLabelIsNotCalledByDefault() throws SOPGPException.UnsupportedOption {
         SopCLI.main(new String[] {"armor"});
         verify(armor, never()).label(any());
@@ -95,14 +83,6 @@ public class ArmorCmdTest {
         when(armor.label(any())).thenThrow(new SOPGPException.UnsupportedOption("Custom Armor labels are not supported."));
 
         SopCLI.main(new String[] {"armor", "--label", "Sig"});
-    }
-
-    @Test
-    @ExpectSystemExitWithStatus(37)
-    public void ifAllowNestedUnsupportedExit37() throws SOPGPException.UnsupportedOption {
-        when(armor.allowNested()).thenThrow(new SOPGPException.UnsupportedOption("Allowing nested Armor not supported."));
-
-        SopCLI.main(new String[] {"armor", "--allow-nested"});
     }
 
     @Test

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/EncryptCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/EncryptCmdTest.java
@@ -65,7 +65,7 @@ public class EncryptCmdTest {
     @Test
     @ExpectSystemExitWithStatus(37)
     public void as_unsupportedEncryptAsCausesExit37() throws SOPGPException.UnsupportedOption {
-        when(encrypt.mode(any())).thenThrow(new SOPGPException.UnsupportedOption());
+        when(encrypt.mode(any())).thenThrow(new SOPGPException.UnsupportedOption("Setting encryption mode not supported."));
 
         SopCLI.main(new String[] {"encrypt", "--as", "Binary"});
     }
@@ -95,7 +95,7 @@ public class EncryptCmdTest {
     @Test
     @ExpectSystemExitWithStatus(37)
     public void withPassword_unsupportedWithPasswordCausesExit37() throws SOPGPException.PasswordNotHumanReadable, SOPGPException.UnsupportedOption {
-        when(encrypt.withPassword(any())).thenThrow(new SOPGPException.UnsupportedOption());
+        when(encrypt.withPassword(any())).thenThrow(new SOPGPException.UnsupportedOption("Encrypting with password not supported."));
 
         SopCLI.main(new String[] {"encrypt", "--with-password", "orange"});
     }
@@ -110,14 +110,14 @@ public class EncryptCmdTest {
     }
 
     @Test
-    @ExpectSystemExitWithStatus(1)
-    public void signWith_nonExistentKeyFileCausesExit1() {
+    @ExpectSystemExitWithStatus(61)
+    public void signWith_nonExistentKeyFileCausesExit61() {
         SopCLI.main(new String[] {"encrypt", "--with-password", "admin", "--sign-with", "nonExistent.asc"});
     }
 
     @Test
-    @ExpectSystemExitWithStatus(1)
-    public void signWith_keyIsProtectedCausesExit1() throws SOPGPException.KeyIsProtected, SOPGPException.UnsupportedAsymmetricAlgo, SOPGPException.CertCannotSign, SOPGPException.BadData, IOException {
+    @ExpectSystemExitWithStatus(67)
+    public void signWith_keyIsProtectedCausesExit67() throws SOPGPException.KeyIsProtected, SOPGPException.UnsupportedAsymmetricAlgo, SOPGPException.CertCannotSign, SOPGPException.BadData, IOException {
         when(encrypt.signWith(any())).thenThrow(new SOPGPException.KeyIsProtected());
         File keyFile = File.createTempFile("sign-with", ".asc");
         SopCLI.main(new String[] {"encrypt", "--sign-with", keyFile.getAbsolutePath(), "--with-password", "starship"});
@@ -126,7 +126,7 @@ public class EncryptCmdTest {
     @Test
     @ExpectSystemExitWithStatus(13)
     public void signWith_unsupportedAsymmetricAlgoCausesExit13() throws SOPGPException.KeyIsProtected, SOPGPException.UnsupportedAsymmetricAlgo, SOPGPException.CertCannotSign, SOPGPException.BadData, IOException {
-        when(encrypt.signWith(any())).thenThrow(new SOPGPException.UnsupportedAsymmetricAlgo(new Exception()));
+        when(encrypt.signWith(any())).thenThrow(new SOPGPException.UnsupportedAsymmetricAlgo("Unsupported asymmetric algorithm.", new Exception()));
         File keyFile = File.createTempFile("sign-with", ".asc");
         SopCLI.main(new String[] {"encrypt", "--with-password", "123456", "--sign-with", keyFile.getAbsolutePath()});
     }
@@ -148,15 +148,15 @@ public class EncryptCmdTest {
     }
 
     @Test
-    @ExpectSystemExitWithStatus(1)
-    public void cert_nonExistentCertFileCausesExit1() {
+    @ExpectSystemExitWithStatus(61)
+    public void cert_nonExistentCertFileCausesExit61() {
         SopCLI.main(new String[] {"encrypt", "invalid.asc"});
     }
 
     @Test
     @ExpectSystemExitWithStatus(13)
     public void cert_unsupportedAsymmetricAlgorithmCausesExit13() throws IOException, SOPGPException.UnsupportedAsymmetricAlgo, SOPGPException.CertCannotEncrypt, SOPGPException.BadData {
-        when(encrypt.withCert(any())).thenThrow(new SOPGPException.UnsupportedAsymmetricAlgo(new Exception()));
+        when(encrypt.withCert(any())).thenThrow(new SOPGPException.UnsupportedAsymmetricAlgo("Unsupported asymmetric algorithm.", new Exception()));
         File certFile = File.createTempFile("cert", ".asc");
         SopCLI.main(new String[] {"encrypt", certFile.getAbsolutePath()});
     }
@@ -164,7 +164,7 @@ public class EncryptCmdTest {
     @Test
     @ExpectSystemExitWithStatus(17)
     public void cert_certCannotEncryptCausesExit17() throws IOException, SOPGPException.UnsupportedAsymmetricAlgo, SOPGPException.CertCannotEncrypt, SOPGPException.BadData {
-        when(encrypt.withCert(any())).thenThrow(new SOPGPException.CertCannotEncrypt());
+        when(encrypt.withCert(any())).thenThrow(new SOPGPException.CertCannotEncrypt("Certificate cannot encrypt.", new Exception()));
         File certFile = File.createTempFile("cert", ".asc");
         SopCLI.main(new String[] {"encrypt", certFile.getAbsolutePath()});
     }

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/EncryptCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/EncryptCmdTest.java
@@ -58,7 +58,7 @@ public class EncryptCmdTest {
 
     @Test
     @ExpectSystemExitWithStatus(19)
-    public void missingPasswordAndCertFileCauseExit19() {
+    public void missingBothPasswordAndCertFileCauseExit19() {
         SopCLI.main(new String[] {"encrypt", "--no-armor"});
     }
 

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/GenerateKeyCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/GenerateKeyCmdTest.java
@@ -91,7 +91,7 @@ public class GenerateKeyCmdTest {
     @Test
     @ExpectSystemExitWithStatus(13)
     public void unsupportedAsymmetricAlgorithmCausesExit13() throws SOPGPException.UnsupportedAsymmetricAlgo, SOPGPException.MissingArg, IOException {
-        when(generateKey.generate()).thenThrow(new SOPGPException.UnsupportedAsymmetricAlgo(new Exception()));
+        when(generateKey.generate()).thenThrow(new SOPGPException.UnsupportedAsymmetricAlgo("Unsupported asymmetric algorithm.", new Exception()));
         SopCLI.main(new String[] {"generate-key", "Alice"});
     }
 

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/SignCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/SignCmdTest.java
@@ -74,7 +74,7 @@ public class SignCmdTest {
     @Test
     @ExpectSystemExitWithStatus(37)
     public void as_unsupportedOptionCausesExit37() throws SOPGPException.UnsupportedOption {
-        when(sign.mode(any())).thenThrow(new SOPGPException.UnsupportedOption());
+        when(sign.mode(any())).thenThrow(new SOPGPException.UnsupportedOption("Setting signing mode not supported."));
         SopCLI.main(new String[] {"sign", "--as", "binary", keyFile.getAbsolutePath()});
     }
 

--- a/sop-java-picocli/src/test/java/sop/cli/picocli/commands/VerifyCmdTest.java
+++ b/sop-java-picocli/src/test/java/sop/cli/picocli/commands/VerifyCmdTest.java
@@ -106,7 +106,7 @@ public class VerifyCmdTest {
     @Test
     @ExpectSystemExitWithStatus(37)
     public void notAfter_unsupportedOptionCausesExit37() throws SOPGPException.UnsupportedOption {
-        when(verify.notAfter(any())).thenThrow(new SOPGPException.UnsupportedOption());
+        when(verify.notAfter(any())).thenThrow(new SOPGPException.UnsupportedOption("Setting upper signature date boundary not supported."));
         SopCLI.main(new String[] {"verify", "--not-after", "2019-10-29T18:36:45Z", signature.getAbsolutePath(), cert.getAbsolutePath()});
     }
 
@@ -133,7 +133,7 @@ public class VerifyCmdTest {
     @Test
     @ExpectSystemExitWithStatus(37)
     public void notBefore_unsupportedOptionCausesExit37() throws SOPGPException.UnsupportedOption {
-        when(verify.notBefore(any())).thenThrow(new SOPGPException.UnsupportedOption());
+        when(verify.notBefore(any())).thenThrow(new SOPGPException.UnsupportedOption("Setting lower signature date boundary not supported."));
         SopCLI.main(new String[] {"verify", "--not-before", "2019-10-29T18:36:45Z", signature.getAbsolutePath(), cert.getAbsolutePath()});
     }
 

--- a/sop-java/src/main/java/sop/ReadyWithResult.java
+++ b/sop-java/src/main/java/sop/ReadyWithResult.java
@@ -23,6 +23,16 @@ import sop.exception.SOPGPException;
 
 public abstract class ReadyWithResult<T> {
 
+    /**
+     * Write the data eg. decrypted plaintext to the provided output stream and return the result of the
+     * processing operation.
+     *
+     * @param outputStream output stream
+     * @return result, eg. signatures
+     *
+     * @throws IOException in case of an IO error
+     * @throws SOPGPException.NoSignature
+     */
     public abstract T writeTo(OutputStream outputStream) throws IOException, SOPGPException.NoSignature;
 
     public ByteArrayAndResult<T> toBytes() throws IOException, SOPGPException.NoSignature {

--- a/sop-java/src/main/java/sop/SOP.java
+++ b/sop-java/src/main/java/sop/SOP.java
@@ -18,6 +18,7 @@ package sop;
 import sop.operation.Armor;
 import sop.operation.Dearmor;
 import sop.operation.Decrypt;
+import sop.operation.DetachInbandSignatureAndMessage;
 import sop.operation.Encrypt;
 import sop.operation.ExtractCert;
 import sop.operation.GenerateKey;
@@ -100,4 +101,6 @@ public interface SOP {
      * @return builder instance
      */
     Dearmor dearmor();
+
+    DetachInbandSignatureAndMessage detachInbandSignatureAndMessage();
 }

--- a/sop-java/src/main/java/sop/Signatures.java
+++ b/sop-java/src/main/java/sop/Signatures.java
@@ -15,30 +15,18 @@
  */
 package sop;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public abstract class Ready {
+public abstract class Signatures extends Ready {
 
     /**
-     * Write the data to the provided output stream.
+     * Write OpenPGP signatures to the provided output stream.
      *
-     * @param outputStream output stream
+     * @param signatureOutputStream output stream
      * @throws IOException in case of an IO error
      */
-    public abstract void writeTo(OutputStream outputStream) throws IOException;
+    @Override
+    public abstract void writeTo(OutputStream signatureOutputStream) throws IOException;
 
-    /**
-     * Return the data as a byte array by writing it to a {@link ByteArrayOutputStream} first and then returning
-     * the array.
-     *
-     * @return data as byte array
-     * @throws IOException in case of an IO error
-     */
-    public byte[] getBytes() throws IOException {
-        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
-        writeTo(bytes);
-        return bytes.toByteArray();
-    }
 }

--- a/sop-java/src/main/java/sop/exception/SOPGPException.java
+++ b/sop-java/src/main/java/sop/exception/SOPGPException.java
@@ -253,6 +253,10 @@ public abstract class SOPGPException extends RuntimeException {
 
         public static final int EXIT_CODE = 73;
 
+        public AmbiguousInput(String message) {
+            super(message);
+        }
+
         @Override
         public int getExitCode() {
             return EXIT_CODE;

--- a/sop-java/src/main/java/sop/exception/SOPGPException.java
+++ b/sop-java/src/main/java/sop/exception/SOPGPException.java
@@ -15,7 +15,7 @@
  */
 package sop.exception;
 
-public class SOPGPException extends Exception {
+public abstract class SOPGPException extends RuntimeException {
 
     public SOPGPException() {
         super();
@@ -29,10 +29,21 @@ public class SOPGPException extends Exception {
         super(e);
     }
 
+    public SOPGPException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public abstract int getExitCode();
+
     public static class NoSignature extends SOPGPException {
 
         public static final int EXIT_CODE = 3;
 
+        public NoSignature() {
+            super("No verifiable signature found.");
+        }
+
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -42,10 +53,15 @@ public class SOPGPException extends Exception {
 
         public static final int EXIT_CODE = 13;
 
+        public UnsupportedAsymmetricAlgo(String message, Throwable e) {
+            super(message, e);
+        }
+
         public UnsupportedAsymmetricAlgo(Throwable e) {
             super(e);
         }
 
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -54,12 +70,17 @@ public class SOPGPException extends Exception {
     public static class CertCannotEncrypt extends SOPGPException {
         public static final int EXIT_CODE = 17;
 
+        public CertCannotEncrypt(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
     }
 
-    public static class CertCannotSign extends SOPGPException {
+    public static class CertCannotSign extends Exception {
 
     }
 
@@ -71,6 +92,7 @@ public class SOPGPException extends Exception {
             super(s);
         }
 
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -80,6 +102,11 @@ public class SOPGPException extends Exception {
 
         public static final int EXIT_CODE = 23;
 
+        public IncompleteVerification(String message) {
+            super(message);
+        }
+
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -89,6 +116,7 @@ public class SOPGPException extends Exception {
 
         public static final int EXIT_CODE = 29;
 
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -98,6 +126,7 @@ public class SOPGPException extends Exception {
 
         public static final int EXIT_CODE = 31;
 
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -107,6 +136,15 @@ public class SOPGPException extends Exception {
 
         public static final int EXIT_CODE = 37;
 
+        public UnsupportedOption(String message) {
+            super(message);
+        }
+
+        public UnsupportedOption(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -120,6 +158,11 @@ public class SOPGPException extends Exception {
             super(e);
         }
 
+        public BadData(String message, BadData badData) {
+            super(message, badData);
+        }
+
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -129,6 +172,7 @@ public class SOPGPException extends Exception {
 
         public static final int EXIT_CODE = 53;
 
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }
@@ -136,20 +180,80 @@ public class SOPGPException extends Exception {
 
     public static class OutputExists extends SOPGPException {
 
+        public static final int EXIT_CODE = 59;
+
+        public OutputExists(String message) {
+            super(message);
+        }
+
+        @Override
+        public int getExitCode() {
+            return EXIT_CODE;
+        }
+    }
+
+    public static class MissingInput extends SOPGPException {
+
+        public static final int EXIT_CODE = 61;
+
+        public MissingInput(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        @Override
+        public int getExitCode() {
+            return EXIT_CODE;
+        }
     }
 
     public static class KeyIsProtected extends SOPGPException {
 
+        public static final int EXIT_CODE = 67;
+
+        public KeyIsProtected() {
+            super();
+        }
+
+        public KeyIsProtected(String message, Throwable cause) {
+            super(message, cause);
+        }
+
+        @Override
+        public int getExitCode() {
+            return EXIT_CODE;
+        }
     }
 
-    public static class AmbiguousInput extends SOPGPException {
-
-    }
-
-    public static class NotImplemented extends SOPGPException {
+    public static class UnsupportedSubcommand extends SOPGPException {
 
         public static final int EXIT_CODE = 69;
 
+        public UnsupportedSubcommand(String message) {
+            super(message);
+        }
+
+        @Override
+        public int getExitCode() {
+            return EXIT_CODE;
+        }
+    }
+
+    public static class UnsupportedSpecialPrefix extends SOPGPException {
+
+        public static final int EXIT_CODE = 71;
+
+        @Override
+        public int getExitCode() {
+            return EXIT_CODE;
+        }
+    }
+
+
+    public static class AmbiguousInput extends SOPGPException {
+
+        public static final int EXIT_CODE = 73;
+
+        @Override
         public int getExitCode() {
             return EXIT_CODE;
         }

--- a/sop-java/src/main/java/sop/operation/Armor.java
+++ b/sop-java/src/main/java/sop/operation/Armor.java
@@ -32,13 +32,6 @@ public interface Armor {
     Armor label(ArmorLabel label) throws SOPGPException.UnsupportedOption;
 
     /**
-     * Allow nested Armoring.
-     *
-     * @return builder instance
-     */
-    Armor allowNested() throws SOPGPException.UnsupportedOption;
-
-    /**
      * Armor the provided data.
      *
      * @param data input stream of unarmored OpenPGP data

--- a/sop-java/src/main/java/sop/operation/DetachInbandSignatureAndMessage.java
+++ b/sop-java/src/main/java/sop/operation/DetachInbandSignatureAndMessage.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Paul Schaub.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sop.operation;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import sop.ReadyWithResult;
+import sop.Signatures;
+
+public interface DetachInbandSignatureAndMessage {
+
+    DetachInbandSignatureAndMessage noArmor();
+
+    ReadyWithResult<Signatures> message(InputStream messageInputStream) throws IOException;
+
+}


### PR DESCRIPTION
This introduces some more error codes, a new subcommand to split signatures from messages and removed some flags.

TODO: The detach-inband-signatures-and-message subcommand does not yet work as intended.
The following flow still fails:
```
CleartextSignatureProcessor.process() <- clearsigned message -> signature ok
detach-inband-signature-and-message <- clearsigned message -> plaintext message, detached sigantures
verify <- detached signatures, message -> signature bad
```
I suspect that the CleartextSignatureProcessor updates signatures in a different way than the normal signature processor?
On the other hand it may be something as stupid as a missing newline.

Fixes #156 