### PR TITLE
Remove support for deleting user-ids and subkeys. Use revoke* instead.

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/key/modification/secretkeyring/SecretKeyRingEditorInterface.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/modification/secretkeyring/SecretKeyRingEditorInterface.java
@@ -22,7 +22,6 @@ import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.util.RevocationAttributes;
 import org.pgpainless.key.util.UserId;
 import org.pgpainless.util.Passphrase;
-import org.pgpainless.util.selection.userid.SelectUserId;
 
 public interface SecretKeyRingEditorInterface {
 
@@ -47,35 +46,6 @@ public interface SecretKeyRingEditorInterface {
     SecretKeyRingEditorInterface addUserId(String userId, SecretKeyRingProtector secretKeyRingProtector) throws PGPException;
 
     /**
-     * Remove a user-id from the key ring.
-     *
-     * @param userId exact user-id to be removed
-     * @param secretKeyRingProtector protector to unlock the secret key
-     * @return the builder
-     */
-    SecretKeyRingEditorInterface deleteUserId(String userId, SecretKeyRingProtector secretKeyRingProtector);
-
-    /**
-     * Remove a user-id from the key ring.
-     *
-     * @param userId exact user-id to be removed
-     * @param secretKeyRingProtector protector to unlock the secret key
-     * @return the builder
-     */
-    default SecretKeyRingEditorInterface deleteUserId(UserId userId, SecretKeyRingProtector secretKeyRingProtector) {
-        return deleteUserId(userId.toString(), secretKeyRingProtector);
-    }
-
-    /**
-     * Delete all user-ids from the key, which match the provided {@link SelectUserId} strategy.
-     *
-     * @param selectionStrategy strategy to select user-ids
-     * @param secretKeyRingProtector protector to unlock the secret key
-     * @return the builder
-     */
-    SecretKeyRingEditorInterface deleteUserIds(SelectUserId selectionStrategy, SecretKeyRingProtector secretKeyRingProtector);
-
-    /**
      * Add a subkey to the key ring.
      * The subkey will be generated from the provided {@link KeySpec}.
      *
@@ -94,29 +64,6 @@ public interface SecretKeyRingEditorInterface {
                                            PGPSignatureSubpacketVector unhashedSubpackets,
                                            SecretKeyRingProtector subKeyProtector, SecretKeyRingProtector keyRingProtector)
             throws PGPException;
-
-    /**
-     * Delete a subkey from the key ring.
-     * The subkey with the provided fingerprint will be remove from the key ring.
-     * If no suitable subkey is found, a {@link java.util.NoSuchElementException} will be thrown.
-     *
-     * @param fingerprint fingerprint of the subkey to be removed
-     * @param secretKeyRingProtector protector to unlock the secret key ring
-     * @return the builder
-     */
-    SecretKeyRingEditorInterface deleteSubKey(OpenPgpFingerprint fingerprint, SecretKeyRingProtector secretKeyRingProtector);
-
-    /**
-     * Delete a subkey from the key ring.
-     * The subkey with the provided key-id will be removed from the key ring.
-     * If no suitable subkey is found, a {@link java.util.NoSuchElementException} will be thrown.
-     *
-     * @param subKeyId id of the subkey
-     * @param secretKeyRingProtector protector to unlock the secret key ring
-     * @return the builder
-     */
-    SecretKeyRingEditorInterface deleteSubKey(long subKeyId, SecretKeyRingProtector secretKeyRingProtector);
-
     /**
      * Revoke the key ring.
      * The revocation will be a hard revocation, rendering the whole key invalid for any past or future signatures.

--- a/pgpainless-core/src/main/java/org/pgpainless/key/util/KeyRingUtils.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/util/KeyRingUtils.java
@@ -154,4 +154,50 @@ public final class KeyRingUtils {
                                                    long keyId) {
         return ring.getPublicKey(keyId) != null;
     }
+
+    /**
+     * Delete the given user-id and its certification signatures from the given key.
+     *
+     * @deprecated Deleting user-ids is highly discouraged, since it might lead to all sorts of problems
+     * (e.g. lost key properties).
+     * Instead, user-ids should only be revoked.
+     *
+     * @param secretKeys secret keys
+     * @param userId user-id
+     * @return modified secret keys
+     */
+    @Deprecated
+    public PGPSecretKeyRing deleteUserIdFromSecretKeyRing(PGPSecretKeyRing secretKeys, String userId) {
+        PGPSecretKey secretKey = secretKeys.getSecretKey(); // user-ids are located on primary key only
+        PGPPublicKey publicKey = secretKey.getPublicKey(); // user-ids are placed on the public key part
+        publicKey = PGPPublicKey.removeCertification(publicKey, userId);
+        if (publicKey == null) {
+            throw new NoSuchElementException("User-ID " + userId + " not found on the key.");
+        }
+        secretKey = PGPSecretKey.replacePublicKey(secretKey, publicKey);
+        secretKeys = PGPSecretKeyRing.insertSecretKey(secretKeys, secretKey);
+        return secretKeys;
+    }
+
+    /**
+     * Delete the given user-id and its certification signatures from the given certificate.
+     *
+     * @deprecated Deleting user-ids is highly discouraged, since it might lead to all sorts of problems
+     * (e.g. lost key properties).
+     * Instead, user-ids should only be revoked.
+     *
+     * @param publicKeys certificate
+     * @param userId user-id
+     * @return modified secret keys
+     */
+    @Deprecated
+    public PGPPublicKeyRing deleteUserIdFromPublicKeyRing(PGPPublicKeyRing publicKeys, String userId) {
+        PGPPublicKey publicKey = publicKeys.getPublicKey(); // user-ids are located on primary key only
+        publicKey = PGPPublicKey.removeCertification(publicKey, userId);
+        if (publicKey == null) {
+            throw new NoSuchElementException("User-ID " + userId + " not found on the key.");
+        }
+        publicKeys = PGPPublicKeyRing.insertPublicKey(publicKeys, publicKey);
+        return publicKeys;
+    }
 }

--- a/pgpainless-core/src/main/java/org/pgpainless/key/util/KeyRingUtils.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/util/KeyRingUtils.java
@@ -167,7 +167,7 @@ public final class KeyRingUtils {
      * @return modified secret keys
      */
     @Deprecated
-    public PGPSecretKeyRing deleteUserIdFromSecretKeyRing(PGPSecretKeyRing secretKeys, String userId) {
+    public static PGPSecretKeyRing deleteUserIdFromSecretKeyRing(PGPSecretKeyRing secretKeys, String userId) {
         PGPSecretKey secretKey = secretKeys.getSecretKey(); // user-ids are located on primary key only
         PGPPublicKey publicKey = secretKey.getPublicKey(); // user-ids are placed on the public key part
         publicKey = PGPPublicKey.removeCertification(publicKey, userId);
@@ -191,7 +191,7 @@ public final class KeyRingUtils {
      * @return modified secret keys
      */
     @Deprecated
-    public PGPPublicKeyRing deleteUserIdFromPublicKeyRing(PGPPublicKeyRing publicKeys, String userId) {
+    public static PGPPublicKeyRing deleteUserIdFromPublicKeyRing(PGPPublicKeyRing publicKeys, String userId) {
         PGPPublicKey publicKey = publicKeys.getPublicKey(); // user-ids are located on primary key only
         publicKey = PGPPublicKey.removeCertification(publicKey, userId);
         if (publicKey == null) {

--- a/pgpainless-core/src/test/java/org/pgpainless/key/modification/AddUserIdTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/modification/AddUserIdTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.pgpainless.PGPainless;
 import org.pgpainless.implementation.ImplementationFactory;
 import org.pgpainless.key.TestKeys;
+import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.PasswordBasedSecretKeyRingProtector;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
@@ -30,11 +31,12 @@ public class AddUserIdTest {
 
     @ParameterizedTest
     @MethodSource("org.pgpainless.util.TestImplementationFactoryProvider#provideImplementationFactories")
-    public void addUserIdToExistingKeyRing(ImplementationFactory implementationFactory) throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, PGPException {
+    public void addUserIdToExistingKeyRing(ImplementationFactory implementationFactory) throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, PGPException, InterruptedException {
         ImplementationFactory.setFactoryImplementation(implementationFactory);
         PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing().simpleEcKeyRing("alice@wonderland.lit", "rabb1th0le");
 
-        Iterator<String> userIds = secretKeys.getSecretKey().getPublicKey().getUserIDs();
+        KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
+        Iterator<String> userIds = info.getValidUserIds().iterator();
         assertEquals("alice@wonderland.lit", userIds.next());
         assertFalse(userIds.hasNext());
 
@@ -43,16 +45,18 @@ public class AddUserIdTest {
                 .addUserId("cheshirecat@wonderland.lit", protector)
                 .done();
 
-        userIds = secretKeys.getPublicKey().getUserIDs();
+        info = PGPainless.inspectKeyRing(secretKeys);
+        userIds = info.getValidUserIds().iterator();
         assertEquals("alice@wonderland.lit", userIds.next());
         assertEquals("cheshirecat@wonderland.lit", userIds.next());
         assertFalse(userIds.hasNext());
 
         secretKeys = PGPainless.modifyKeyRing(secretKeys)
-                .deleteUserId("cheshirecat@wonderland.lit", protector)
+                .revokeUserId("cheshirecat@wonderland.lit", protector)
                 .done();
 
-        userIds = secretKeys.getPublicKey().getUserIDs();
+        info = PGPainless.inspectKeyRing(secretKeys);
+        userIds = info.getValidUserIds().iterator();
         assertEquals("alice@wonderland.lit", userIds.next());
         assertFalse(userIds.hasNext());
     }
@@ -64,7 +68,7 @@ public class AddUserIdTest {
 
         PGPSecretKeyRing secretKeys = TestKeys.getCryptieSecretKeyRing();
         assertThrows(NoSuchElementException.class, () -> PGPainless.modifyKeyRing(secretKeys)
-                .deleteUserId("invalid@user.id", new UnprotectedKeysProtector()));
+                .revokeUserId("invalid@user.id", new UnprotectedKeysProtector()));
     }
 
     @ParameterizedTest
@@ -89,17 +93,19 @@ public class AddUserIdTest {
                         "-----END PGP PRIVATE KEY BLOCK-----\r\n";
 
         PGPSecretKeyRing secretKeys = PGPainless.readKeyRing().secretKeyRing(ARMORED_PRIVATE_KEY);
-        Iterator<String> userIds = secretKeys.getSecretKey().getPublicKey().getUserIDs();
+        KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
+        Iterator<String> userIds = info.getValidUserIds().iterator();
         assertEquals("<user@example.com>", userIds.next());
         assertFalse(userIds.hasNext());
 
         SecretKeyRingProtector protector = new UnprotectedKeysProtector();
         secretKeys = PGPainless.modifyKeyRing(secretKeys)
-                .deleteUserId("<user@example.com>", protector)
+                .revokeUserId("<user@example.com>", protector)
                 .addUserId("cheshirecat@wonderland.lit", protector)
                 .done();
 
-        userIds = secretKeys.getSecretKey().getPublicKey().getUserIDs();
+        info = PGPainless.inspectKeyRing(secretKeys);
+        userIds = info.getValidUserIds().iterator();
         assertEquals("cheshirecat@wonderland.lit", userIds.next());
         assertFalse(userIds.hasNext());
     }

--- a/pgpainless-core/src/test/java/org/pgpainless/key/util/KeyRingUtilTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/util/KeyRingUtilTest.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2021 Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.pgpainless.key.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.junit.jupiter.api.Test;
+import org.pgpainless.PGPainless;
+import org.pgpainless.key.protection.SecretKeyRingProtector;
+import org.pgpainless.util.CollectionUtils;
+
+public class KeyRingUtilTest {
+
+    @Test
+    public void testDeleteUserIdFromSecretKeyRing()
+            throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
+                .modernKeyRing("Alice", null);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .addUserId("Bob", SecretKeyRingProtector.unprotectedKeys())
+                .done();
+        assertEquals(2, CollectionUtils.iteratorToList(secretKeys.getPublicKey().getUserIDs()).size());
+
+        secretKeys = KeyRingUtils.deleteUserIdFromSecretKeyRing(secretKeys, "Bob");
+
+        assertEquals(1, CollectionUtils.iteratorToList(secretKeys.getPublicKey().getUserIDs()).size());
+    }
+
+    @Test
+    public void testDeleteUserIdFromPublicKeyRing() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
+                .modernKeyRing("Alice", null);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .addUserId("Bob", SecretKeyRingProtector.unprotectedKeys())
+                .done();
+        PGPPublicKeyRing publicKeys = PGPainless.extractCertificate(secretKeys);
+        assertEquals(2, CollectionUtils.iteratorToList(publicKeys.getPublicKey().getUserIDs()).size());
+
+        publicKeys = KeyRingUtils.deleteUserIdFromPublicKeyRing(publicKeys, "Alice");
+
+        assertEquals(1, CollectionUtils.iteratorToList(publicKeys.getPublicKey().getUserIDs()).size());
+    }
+}

--- a/pgpainless-core/src/test/java/org/pgpainless/key/util/KeyRingUtilTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/util/KeyRingUtilTest.java
@@ -5,9 +5,11 @@
 package org.pgpainless.key.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
+import java.util.NoSuchElementException;
 
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
@@ -36,7 +38,8 @@ public class KeyRingUtilTest {
     }
 
     @Test
-    public void testDeleteUserIdFromPublicKeyRing() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+    public void testDeleteUserIdFromPublicKeyRing()
+            throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
                 .modernKeyRing("Alice", null);
 
@@ -49,5 +52,15 @@ public class KeyRingUtilTest {
         publicKeys = KeyRingUtils.deleteUserIdFromPublicKeyRing(publicKeys, "Alice");
 
         assertEquals(1, CollectionUtils.iteratorToList(publicKeys.getPublicKey().getUserIDs()).size());
+    }
+
+    @Test
+    public void testDeleteNonexistentUserIdFromKeyRingThrows()
+            throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
+                .modernKeyRing("Alice", null);
+
+        assertThrows(NoSuchElementException.class,
+                () -> KeyRingUtils.deleteUserIdFromSecretKeyRing(secretKeys, "Charlie"));
     }
 }


### PR DESCRIPTION
See #210 

@tomholub @DenBond7 I hope you do not rely on this functionality. Please let me know if you have objections to this, though I learned that deleting should not be used at all in OpenPGP.