### PR TITLE
Fix accidental compile dependency on logback-classic

### DIFF
--- a/pgpainless-core/build.gradle
+++ b/pgpainless-core/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     // Logging
     api "org.slf4j:slf4j-api:$slf4jVersion"
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
-    runtime "ch.qos.logback:logback-classic:$logbackVersion"
 
     api "org.bouncycastle:bcprov-jdk15on:$bouncyCastleVersion"
     api "org.bouncycastle:bcpg-jdk15on:$bouncyCastleVersion"

--- a/pgpainless-core/src/main/java/org/pgpainless/key/util/KeyRingUtils.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/util/KeyRingUtils.java
@@ -167,7 +167,7 @@ public final class KeyRingUtils {
      * @return modified secret keys
      */
     @Deprecated
-    public static PGPSecretKeyRing deleteUserIdFromSecretKeyRing(PGPSecretKeyRing secretKeys, String userId) {
+    public static PGPSecretKeyRing deleteUserId(PGPSecretKeyRing secretKeys, String userId) {
         PGPSecretKey secretKey = secretKeys.getSecretKey(); // user-ids are located on primary key only
         PGPPublicKey publicKey = secretKey.getPublicKey(); // user-ids are placed on the public key part
         publicKey = PGPPublicKey.removeCertification(publicKey, userId);
@@ -191,7 +191,7 @@ public final class KeyRingUtils {
      * @return modified secret keys
      */
     @Deprecated
-    public static PGPPublicKeyRing deleteUserIdFromPublicKeyRing(PGPPublicKeyRing publicKeys, String userId) {
+    public static PGPPublicKeyRing deleteUserId(PGPPublicKeyRing publicKeys, String userId) {
         PGPPublicKey publicKey = publicKeys.getPublicKey(); // user-ids are located on primary key only
         publicKey = PGPPublicKey.removeCertification(publicKey, userId);
         if (publicKey == null) {

--- a/pgpainless-core/src/test/java/org/pgpainless/key/util/KeyRingUtilTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/util/KeyRingUtilTest.java
@@ -32,7 +32,7 @@ public class KeyRingUtilTest {
                 .done();
         assertEquals(2, CollectionUtils.iteratorToList(secretKeys.getPublicKey().getUserIDs()).size());
 
-        secretKeys = KeyRingUtils.deleteUserIdFromSecretKeyRing(secretKeys, "Bob");
+        secretKeys = KeyRingUtils.deleteUserId(secretKeys, "Bob");
 
         assertEquals(1, CollectionUtils.iteratorToList(secretKeys.getPublicKey().getUserIDs()).size());
     }
@@ -49,7 +49,7 @@ public class KeyRingUtilTest {
         PGPPublicKeyRing publicKeys = PGPainless.extractCertificate(secretKeys);
         assertEquals(2, CollectionUtils.iteratorToList(publicKeys.getPublicKey().getUserIDs()).size());
 
-        publicKeys = KeyRingUtils.deleteUserIdFromPublicKeyRing(publicKeys, "Alice");
+        publicKeys = KeyRingUtils.deleteUserId(publicKeys, "Alice");
 
         assertEquals(1, CollectionUtils.iteratorToList(publicKeys.getPublicKey().getUserIDs()).size());
     }
@@ -61,6 +61,6 @@ public class KeyRingUtilTest {
                 .modernKeyRing("Alice", null);
 
         assertThrows(NoSuchElementException.class,
-                () -> KeyRingUtils.deleteUserIdFromSecretKeyRing(secretKeys, "Charlie"));
+                () -> KeyRingUtils.deleteUserId(secretKeys, "Charlie"));
     }
 }

--- a/pgpainless-sop/build.gradle
+++ b/pgpainless-sop/build.gradle
@@ -18,7 +18,6 @@ dependencies {
 
     // Logging
     testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
-    runtime "ch.qos.logback:logback-classic:$logbackVersion"
 
     implementation(project(":pgpainless-core"))
     implementation(project(":sop-java"))


### PR DESCRIPTION
See #214 for more details.

Fixed by completely removing the dependency on `logback-classic` in non-test scopes, as the dependency was intended to be optional anyways.

@bjansen Does this fix the issue for you?

Dependencies section from generated `pgpainless-core/build/publications/mavenJava/pom-default.xml` after applying this change:
```
  <dependencies>
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.32</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcprov-jdk15on</artifactId>
      <version>1.69</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.bouncycastle</groupId>
      <artifactId>bcpg-jdk15on</artifactId>
      <version>1.69</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>com.google.code.findbugs</groupId>
      <artifactId>jsr305</artifactId>
      <version>3.0.2</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
```