### PR TITLE
Simplify setExpirationDate() API

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/key/modification/secretkeyring/SecretKeyRingEditorInterface.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/modification/secretkeyring/SecretKeyRingEditorInterface.java
@@ -367,20 +367,6 @@ public interface SecretKeyRingEditorInterface {
             throws PGPException;
 
     /**
-     * Set key expiration time.
-     *
-     * @param fingerprint key that will have its expiration date adjusted
-     * @param expiration target expiration time or @{code null} for no expiration
-     * @param secretKeyRingProtector protector to unlock the priary key
-     * @return the builder
-     */
-    SecretKeyRingEditorInterface setExpirationDate(
-            @Nonnull OpenPgpFingerprint fingerprint,
-            @Nullable Date expiration,
-            @Nonnull SecretKeyRingProtector secretKeyRingProtector)
-            throws PGPException;
-
-    /**
      * Create a detached revocation certificate, which can be used to revoke the whole key.
      *
      * @param secretKeyRingProtector protector to unlock the primary key.

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/builder/SubkeyBindingSignatureBuilder.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/builder/SubkeyBindingSignatureBuilder.java
@@ -21,6 +21,21 @@ public class SubkeyBindingSignatureBuilder extends AbstractSignatureBuilder<Subk
         super(SignatureType.SUBKEY_BINDING, signingKey, protector);
     }
 
+    public SubkeyBindingSignatureBuilder(
+            PGPSecretKey signingKey,
+            SecretKeyRingProtector protector,
+            PGPSignature oldSubkeyBinding)
+            throws PGPException {
+        super(signingKey, protector, requireValidSignatureType(oldSubkeyBinding));
+    }
+
+    private static PGPSignature requireValidSignatureType(PGPSignature signature) {
+        if (signature.getSignatureType() == SignatureType.SUBKEY_BINDING.getCode()) {
+            return signature;
+        }
+        throw new IllegalArgumentException("Invalid signature type.");
+    }
+
     @Override
     protected boolean isValidSignatureType(SignatureType type) {
         return type == SignatureType.SUBKEY_BINDING;

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/consumer/SignaturePicker.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/consumer/SignaturePicker.java
@@ -237,10 +237,6 @@ public final class SignaturePicker {
                 SignatureValidator.signatureIsCertification().verify(signature);
                 SignatureValidator.signatureStructureIsAcceptable(primaryKey, policy).verify(signature);
                 SignatureValidator.signatureIsAlreadyEffective(validationDate).verify(signature);
-                // if the currently latest signature is not yet expired, check if the next candidate is not yet expired
-                if (latestUserIdCert != null && !SignatureUtils.isSignatureExpired(latestUserIdCert, validationDate)) {
-                    SignatureValidator.signatureIsNotYetExpired(validationDate).verify(signature);
-                }
                 SignatureValidator.correctSignatureOverUserId(userId, primaryKey, primaryKey).verify(signature);
             } catch (SignatureValidationException e) {
                 // User-id certification is not valid

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpacketsUtil.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpacketsUtil.java
@@ -195,13 +195,14 @@ public final class SignatureSubpacketsUtil {
      * @return key expiration time as date
      */
     public static Date getKeyExpirationTimeAsDate(PGPSignature signature, PGPPublicKey signingKey) {
+        if (signature.getKeyID() != signingKey.getKeyID()) {
+            throw new IllegalArgumentException("Provided key (" + Long.toHexString(signingKey.getKeyID()) + ") did not create the signature (" + Long.toHexString(signature.getKeyID()) + ")");
+        }
         KeyExpirationTime subpacket = getKeyExpirationTime(signature);
         if (subpacket == null) {
             return null;
         }
-        if (signature.getKeyID() != signingKey.getKeyID()) {
-            throw new IllegalArgumentException("Provided key (" + Long.toHexString(signingKey.getKeyID()) + ") did not create the signature (" + Long.toHexString(signature.getKeyID()) + ")");
-        }
+
         return SignatureUtils.datePlusSeconds(signingKey.getCreationTime(), subpacket.getTime());
     }
 

--- a/pgpainless-core/src/test/java/org/pgpainless/example/ModifyKeys.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/example/ModifyKeys.java
@@ -6,7 +6,6 @@ package org.pgpainless.example;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -26,7 +25,6 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.EncryptionPurpose;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.exception.WrongPassphraseException;
-import org.pgpainless.key.OpenPgpFingerprint;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
@@ -221,33 +219,6 @@ public class ModifyKeys {
                 DateUtil.formatUTCDate(info.getExpirationDateForUse(KeyFlag.ENCRYPT_COMMS)));
         assertEquals(DateUtil.formatUTCDate(expirationDate),
                 DateUtil.formatUTCDate(info.getExpirationDateForUse(KeyFlag.SIGN_DATA)));
-    }
-
-    /**
-     * This example demonstrates how to set an expiration date for single subkeys.
-     *
-     * @throws PGPException
-     */
-    @Test
-    public void setSubkeyExpirationDate() throws PGPException {
-        Date expirationDate = DateUtil.parseUTCDate("2032-01-13 22:30:01 UTC");
-        SecretKeyRingProtector protector = SecretKeyRingProtector
-                .unlockEachKeyWith(Passphrase.fromPassword(originalPassphrase), secretKey);
-
-        secretKey = PGPainless.modifyKeyRing(secretKey)
-                .setExpirationDate(
-                        OpenPgpFingerprint.of(secretKey.getPublicKey(encryptionSubkeyId)),
-                        expirationDate,
-                        protector
-                )
-                .done();
-
-
-        KeyRingInfo info = PGPainless.inspectKeyRing(secretKey);
-        assertNull(info.getPrimaryKeyExpirationDate());
-        assertNull(info.getExpirationDateForUse(KeyFlag.SIGN_DATA));
-        assertEquals(DateUtil.formatUTCDate(expirationDate),
-                DateUtil.formatUTCDate(info.getExpirationDateForUse(KeyFlag.ENCRYPT_COMMS)));
     }
 
     /**

--- a/pgpainless-core/src/test/java/org/pgpainless/key/info/KeyRingInfoTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/info/KeyRingInfoTest.java
@@ -237,19 +237,15 @@ public class KeyRingInfoTest {
 
         calendar.setTime(now);
         calendar.add(Calendar.DATE, 10);
-        Date encryptionKeyExpiration = calendar.getTime(); // in 10 days
         PGPSecretKey encryptionKey = keys.next();
 
         calendar.setTime(now);
         calendar.add(Calendar.DATE, 3);
-        Date signingKeyExpiration = calendar.getTime(); // in 3 days
         PGPSecretKey signingKey = keys.next();
 
         SecretKeyRingProtector protector = SecretKeyRingProtector.unprotectedKeys();
         secretKeys = PGPainless.modifyKeyRing(secretKeys)
-                .setExpirationDate(new OpenPgpV4Fingerprint(primaryKey), primaryKeyExpiration, protector)
-                .setExpirationDate(new OpenPgpV4Fingerprint(encryptionKey), encryptionKeyExpiration, protector)
-                .setExpirationDate(new OpenPgpV4Fingerprint(signingKey), signingKeyExpiration, protector)
+                .setExpirationDate(primaryKeyExpiration, protector)
                 .done();
 
         KeyRingInfo info = new KeyRingInfo(secretKeys);
@@ -267,7 +263,6 @@ public class KeyRingInfoTest {
         assertEquals(primaryKey.getKeyID(), certKeys.get(0).getKeyID());
 
         assertEquals(primaryKeyExpiration.getTime(), info.getPrimaryKeyExpirationDate().getTime(), 5);
-        assertEquals(signingKeyExpiration.getTime(), info.getExpirationDateForUse(KeyFlag.SIGN_DATA).getTime(), 5);
 
         // Encryption key expires after primary key, so we return primary key expiration instead.
         assertEquals(primaryKeyExpiration.getTime(), info.getExpirationDateForUse(KeyFlag.ENCRYPT_STORAGE).getTime(), 5);

--- a/pgpainless-core/src/test/java/org/pgpainless/key/modification/ChangePrimaryUserIdAndExpirationDatesTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/modification/ChangePrimaryUserIdAndExpirationDatesTest.java
@@ -1,0 +1,224 @@
+// SPDX-FileCopyrightText: 2020 Paul Schaub <vanitasvitae@fsfe.org>, 2021 Flowcrypt a.s.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.pgpainless.key.modification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+
+import org.bouncycastle.openpgp.PGPException;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.bouncycastle.openpgp.PGPSignature;
+import org.junit.jupiter.api.Test;
+import org.pgpainless.PGPainless;
+import org.pgpainless.key.info.KeyRingInfo;
+import org.pgpainless.key.protection.SecretKeyRingProtector;
+
+public class ChangePrimaryUserIdAndExpirationDatesTest {
+
+    @Test
+    public void generateA_primaryB_revokeA_cantSecondaryA()
+            throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InterruptedException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
+                .modernKeyRing("A", null);
+        SecretKeyRingProtector protector = SecretKeyRingProtector.unprotectedKeys();
+
+        KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
+        assertFalse(info.isHardRevoked("A"));
+        assertFalse(info.isHardRevoked("B"));
+        assertIsPrimaryUserId("A", info);
+        assertIsNotValid("B", info);
+        assertIsNotPrimaryUserId("B", info);
+
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .addPrimaryUserId("B", protector)
+                .done();
+        info = PGPainless.inspectKeyRing(secretKeys);
+
+        assertIsPrimaryUserId("B", info);
+        assertIsNotPrimaryUserId("A", info);
+
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .revokeUserId("A", protector) // hard revoke A
+                .done();
+        info = PGPainless.inspectKeyRing(secretKeys);
+
+        assertTrue(info.isHardRevoked("A"));
+        assertFalse(info.isHardRevoked("B"));
+        assertIsPrimaryUserId("B", info);
+        assertIsNotValid("A", info);
+
+        Thread.sleep(1000);
+
+        PGPSecretKeyRing finalSecretKeys = secretKeys;
+        assertThrows(IllegalArgumentException.class, () ->
+                PGPainless.modifyKeyRing(finalSecretKeys).addUserId("A", protector));
+    }
+
+    @Test
+    public void generateA_primaryExpire_isExpired()
+            throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InterruptedException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
+                .modernKeyRing("A", null);
+        SecretKeyRingProtector protector = SecretKeyRingProtector.unprotectedKeys();
+
+        KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
+        assertIsPrimaryUserId("A", info);
+
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .setExpirationDate(new Date(), protector) // expire the whole key
+                .done();
+
+        Thread.sleep(1000);
+
+        info = PGPainless.inspectKeyRing(secretKeys);
+        assertFalse(info.isUserIdValid("A")); // is expired by now
+    }
+
+    @Test
+    public void generateA_primaryB_primaryExpire_bIsStillPrimary()
+            throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InterruptedException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
+                .modernKeyRing("A", null);
+        SecretKeyRingProtector protector = SecretKeyRingProtector.unprotectedKeys();
+
+        KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
+        assertIsPrimaryUserId("A", info);
+
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .addPrimaryUserId("B", protector)
+                .done();
+        info = PGPainless.inspectKeyRing(secretKeys);
+
+        assertIsPrimaryUserId("B", info);
+        assertIsNotPrimaryUserId("A", info);
+
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .setExpirationDate(new Date(new Date().getTime() + 1000), protector) // expire the whole key in 1 sec
+                .done();
+
+        info = PGPainless.inspectKeyRing(secretKeys);
+        assertIsValid("A", info);
+        assertIsValid("B", info);
+        assertIsPrimaryUserId("B", info);
+        assertIsNotPrimaryUserId("A", info);
+
+        Thread.sleep(2000);
+
+        info = PGPainless.inspectKeyRing(secretKeys);
+        assertIsPrimaryUserId("B", info);   // B is still primary, even though
+        assertFalse(info.isUserIdValid("A"));      // key is expired by now
+        assertFalse(info.isUserIdValid("B"));
+    }
+
+    @Test
+    public void generateA_expire_certify() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InterruptedException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing().modernKeyRing("A", null);
+        SecretKeyRingProtector protector = SecretKeyRingProtector.unprotectedKeys();
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .setExpirationDate(new Date(new Date().getTime() + 1000), protector)
+                .done();
+
+        Thread.sleep(2000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .setExpirationDate(new Date(new Date().getTime() + 2000), protector)
+                .done();
+
+        KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
+        assertIsValid("A", info);
+        assertIsPrimaryUserId("A", info);
+    }
+
+    @Test
+    public void generateA_expire_primaryB_expire_isPrimaryB()
+            throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, InterruptedException, IOException {
+        PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing().modernKeyRing("A", null);
+        SecretKeyRingProtector protector = SecretKeyRingProtector.unprotectedKeys();
+
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .setExpirationDate(new Date(), protector)
+                .done();
+
+        Thread.sleep(2000);
+        KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
+
+        assertIsPrimaryUserId("A", info);
+        assertIsNotValid("A", info);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .addPrimaryUserId("B", protector)
+                .done();
+
+        info = PGPainless.inspectKeyRing(secretKeys);
+
+        assertIsPrimaryUserId("B", info);
+        assertIsValid("B", info);
+        assertIsNotValid("A", info); // A is still expired
+
+        Thread.sleep(1000);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .setExpirationDate(new Date(new Date().getTime() + 10000), protector)
+                .done();
+
+        Thread.sleep(1000);
+        info = PGPainless.inspectKeyRing(secretKeys);
+
+        assertIsValid("B", info);
+        assertIsNotValid("A", info); // A was expired when the expiration date was changed, so it was not re-certified
+        assertIsPrimaryUserId("B", info);
+
+        secretKeys = PGPainless.modifyKeyRing(secretKeys)
+                .addUserId("A", protector) // re-certify A as non-primary user-id
+                .done();
+        info = PGPainless.inspectKeyRing(secretKeys);
+
+        assertIsValid("B", info);
+        assertIsValid("A", info);
+        assertIsPrimaryUserId("B", info);
+
+    }
+
+    private static void assertIsPrimaryUserId(String userId, KeyRingInfo info) {
+        assertEquals(userId, info.getPrimaryUserId());
+    }
+
+    private static void assertIsNotPrimaryUserId(String userId, KeyRingInfo info) {
+        PGPSignature signature = info.getLatestUserIdCertification(userId);
+        if (signature == null) {
+            return;
+        }
+
+        assertFalse(signature.getHashedSubPackets().isPrimaryUserID());
+    }
+
+    private static void assertIsValid(String userId, KeyRingInfo info) {
+        assertTrue(info.isUserIdValid(userId));
+    }
+
+    private static void assertIsNotValid(String userId, KeyRingInfo info) {
+        assertFalse(info.isUserIdValid(userId));
+    }
+}

--- a/pgpainless-core/src/test/java/org/pgpainless/key/modification/OldSignatureSubpacketsArePreservedOnNewSig.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/modification/OldSignatureSubpacketsArePreservedOnNewSig.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Calendar;
 import java.util.Date;
 
 import org.bouncycastle.openpgp.PGPException;
@@ -19,7 +20,6 @@ import org.bouncycastle.openpgp.PGPSignatureSubpacketVector;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.pgpainless.PGPainless;
-import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
 import org.pgpainless.util.TestAllImplementations;
 
@@ -32,18 +32,22 @@ public class OldSignatureSubpacketsArePreservedOnNewSig {
         PGPSecretKeyRing secretKeys = PGPainless.generateKeyRing()
                 .simpleEcKeyRing("Alice <alice@wonderland.lit>");
 
-        OpenPgpV4Fingerprint subkeyFingerprint = new OpenPgpV4Fingerprint(PGPainless.inspectKeyRing(secretKeys).getPublicKeys().get(1));
-
-        PGPSignature oldSignature = PGPainless.inspectKeyRing(secretKeys).getCurrentSubkeyBindingSignature(subkeyFingerprint.getKeyId());
+        PGPSignature oldSignature = PGPainless.inspectKeyRing(secretKeys).getLatestUserIdCertification("Alice <alice@wonderland.lit>");
         PGPSignatureSubpacketVector oldPackets = oldSignature.getHashedSubPackets();
 
         assertEquals(0, oldPackets.getKeyExpirationTime());
 
         Thread.sleep(1000);
+        Date now = new Date();
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(now);
+        calendar.add(Calendar.DATE, 5);
+        Date expiration = calendar.getTime(); // in 5 days
+
         secretKeys = PGPainless.modifyKeyRing(secretKeys)
-                .setExpirationDate(subkeyFingerprint, new Date(), new UnprotectedKeysProtector())
+                .setExpirationDate(expiration, new UnprotectedKeysProtector())
                 .done();
-        PGPSignature newSignature = PGPainless.inspectKeyRing(secretKeys).getCurrentSubkeyBindingSignature(subkeyFingerprint.getKeyId());
+        PGPSignature newSignature = PGPainless.inspectKeyRing(secretKeys).getLatestUserIdCertification("Alice <alice@wonderland.lit>");
         PGPSignatureSubpacketVector newPackets = newSignature.getHashedSubPackets();
 
         assertNotEquals(0, newPackets.getKeyExpirationTime());

--- a/pgpainless-core/src/test/java/org/pgpainless/key/modification/RevokeKeyWithoutPreferredAlgorithmsOnPrimaryKey.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/modification/RevokeKeyWithoutPreferredAlgorithmsOnPrimaryKey.java
@@ -5,18 +5,14 @@
 package org.pgpainless.key.modification;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Date;
-import java.util.List;
 
 import org.bouncycastle.openpgp.PGPException;
-import org.bouncycastle.openpgp.PGPSecretKey;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
 import org.junit.JUtils;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.pgpainless.PGPainless;
-import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.modification.secretkeyring.SecretKeyRingEditorInterface;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
@@ -106,24 +102,15 @@ public class RevokeKeyWithoutPreferredAlgorithmsOnPrimaryKey {
             throws IOException, PGPException {
         Date expirationDate = DateUtil.parseUTCDate(DateUtil.formatUTCDate(new Date()));
         PGPSecretKeyRing secretKeys = PGPainless.readKeyRing().secretKeyRing(KEY);
-        List<OpenPgpV4Fingerprint> fingerprintList = new ArrayList<>();
-        for (PGPSecretKey secretKey : secretKeys) {
-            fingerprintList.add(new OpenPgpV4Fingerprint(secretKey));
-        }
+
         SecretKeyRingProtector protector = new UnprotectedKeysProtector();
 
         SecretKeyRingEditorInterface modify = PGPainless.modifyKeyRing(secretKeys)
                 .setExpirationDate(expirationDate, protector);
-        for (int i = 1; i < fingerprintList.size(); i++) {
-            modify.setExpirationDate(fingerprintList.get(i), expirationDate, protector);
-        }
         secretKeys = modify.done();
 
         KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);
 
         JUtils.assertDateEquals(expirationDate, info.getPrimaryKeyExpirationDate());
-        for (OpenPgpV4Fingerprint fingerprint : fingerprintList) {
-            JUtils.assertDateEquals(expirationDate, info.getSubkeyExpirationDate(fingerprint));
-        }
     }
 }

--- a/pgpainless-core/src/test/java/org/pgpainless/signature/SignatureSubpacketsUtilTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/signature/SignatureSubpacketsUtilTest.java
@@ -60,7 +60,8 @@ public class SignatureSubpacketsUtilTest {
                 .setExpirationDate(expiration, SecretKeyRingProtector.unprotectedKeys())
                 .done();
 
-        PGPSignature expirationSig = SignaturePicker.pickCurrentUserIdCertificationSignature(secretKeys, "Expire", Policy.getInstance(), new Date());
+        PGPSignature expirationSig = SignaturePicker.pickCurrentUserIdCertificationSignature(
+                secretKeys, "Expire", Policy.getInstance(), new Date());
         PGPPublicKey notTheRightKey = PGPainless.inspectKeyRing(secretKeys).getSigningSubkeys().get(0);
 
         assertThrows(IllegalArgumentException.class, () ->


### PR DESCRIPTION
This PR simplifies the API that PGPainless exposes to change expiration dates.
It removes the ability to set separate expiration dates for user-ids and limits expiration date modifications to key expiration only.

Relates to #225 