### PR TITLE
Make use of new CTB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ SPDX-License-Identifier: CC0-1.0
 
 # PGPainless Changelog
 
+## 1.1.0-SNAPSHOT
+- `pgpainless-sop`: Update `sop-java` to version 1.2.0
+  - Treat passwords and session keys as indirect parameters
+
 ## 1.0.3
 - Fix detection of unarmored data in signature verification
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you need more flexibility, directly using `pgpainless-core` is the way to go.
 Most of PGPainless' features can be accessed directly from the `PGPainless` class.
 If you want to get started, this class is your friend :)
 
-For further details you should check out the [javadoc](https://pgpainless.org/releases/latest/javadoc/)!
+For further details you should check out the [javadoc](https://javadoc.io/doc/org.pgpainless/pgpainless-core)!
 
 ### Handle Keys
 Reading keys from ASCII armored strings or from binary files is easy:

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ SPDX-License-Identifier: Apache-2.0
 [![Travis (.com)](https://travis-ci.com/pgpainless/pgpainless.svg?branch=master)](https://travis-ci.com/pgpainless/pgpainless)
 [![Maven Central](https://badgen.net/maven/v/maven-central/org.pgpainless/pgpainless-core)](https://search.maven.org/artifact/org.pgpainless/pgpainless-core)
 [![Coverage Status](https://coveralls.io/repos/github/pgpainless/pgpainless/badge.svg?branch=master)](https://coveralls.io/github/pgpainless/pgpainless?branch=master)
-[![JavaDoc](https://badgen.net/badge/javadoc/yes/green)](https://pgpainless.org/releases/latest/javadoc/)
 [![Interoperability Test-Suite](https://badgen.net/badge/Sequoia%20Test%20Suite/%232/green)](https://tests.sequoia-pgp.org/)
 [![PGP](https://img.shields.io/badge/pgp-A027%20DB2F%203E1E%20118A-blue)](https://keyoxide.org/7F9116FEA90A5983936C7CFAA027DB2F3E1E118A)
 [![REUSE status](https://api.reuse.software/badge/github.com/pgpainless/pgpainless)](https://api.reuse.software/info/github.com/pgpainless/pgpainless)
+
 ## About
 
 PGPainless aims to make using OpenPGP in Java projects as simple as possible.

--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ allprojects {
         slf4jVersion = '1.7.32'
         logbackVersion = '1.2.9'
         junitVersion = '5.8.2'
-        sopJavaVersion = '1.1.0'
+        sopJavaVersion = '1.2.0'
         rootConfigDir = new File(rootDir, 'config')
         gitCommit = getGitCommit()
         isContinuousIntegrationEnvironment = Boolean.parseBoolean(System.getenv('CI'))

--- a/pgpainless-cli/README.md
+++ b/pgpainless-cli/README.md
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 
 # PGPainless-CLI
 
+[![javadoc](https://javadoc.io/badge2/org.pgpainless/pgpainless-cli/javadoc.svg)](https://javadoc.io/doc/org.pgpainless/pgpainless-cli)
+
 PGPainless-CLI is an implementation of the [Stateless OpenPGP Command Line Interface](https://tools.ietf.org/html/draft-dkg-openpgp-stateless-cli-01) specification based on PGPainless.
 
 It plugs `pgpainless-sop` into `sop-java-picocli`.

--- a/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/DearmorTest.java
+++ b/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/DearmorTest.java
@@ -16,6 +16,7 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 
 import com.ginsberg.junit.exit.FailOnSystemExit;
+import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
@@ -51,7 +52,12 @@ public class DearmorTest {
         System.setOut(new PrintStream(out));
         PGPainlessCLI.execute("dearmor");
 
-        assertArrayEquals(secretKey.getEncoded(), out.toByteArray());
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(byteOut, true);
+        secretKey.encode(bcpgOut);
+        bcpgOut.close();
+
+        assertArrayEquals(byteOut.toByteArray(), out.toByteArray());
     }
 
 
@@ -68,7 +74,12 @@ public class DearmorTest {
         System.setOut(new PrintStream(out));
         PGPainlessCLI.execute("dearmor");
 
-        assertArrayEquals(certificate.getEncoded(), out.toByteArray());
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(byteOut, true);
+        certificate.encode(bcpgOut);
+        bcpgOut.close();
+
+        assertArrayEquals(byteOut.toByteArray(), out.toByteArray());
     }
 
     @Test

--- a/pgpainless-core/README.md
+++ b/pgpainless-core/README.md
@@ -6,6 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # PGPainless-Core
 
+[![javadoc](https://javadoc.io/badge2/org.pgpainless/pgpainless-core/javadoc.svg)](https://javadoc.io/doc/org.pgpainless/pgpainless-core)
+[![Maven Central](https://badgen.net/maven/v/maven-central/org.pgpainless/pgpainless-core)](https://search.maven.org/artifact/org.pgpainless/pgpainless-core)
+
 Wrapper around Bouncycastle's OpenPGP implementation.
 
 ## Protection Against Attacks

--- a/pgpainless-core/src/main/java/org/pgpainless/PGPainless.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/PGPainless.java
@@ -4,13 +4,17 @@
 
 package org.pgpainless;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Date;
 import javax.annotation.Nonnull;
 
+import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.openpgp.PGPKeyRing;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.bouncycastle.openpgp.PGPSignature;
 import org.pgpainless.decryption_verification.DecryptionBuilder;
 import org.pgpainless.decryption_verification.DecryptionStream;
 import org.pgpainless.encryption_signing.EncryptionBuilder;
@@ -24,6 +28,7 @@ import org.pgpainless.key.parsing.KeyRingReader;
 import org.pgpainless.key.util.KeyRingUtils;
 import org.pgpainless.policy.Policy;
 import org.pgpainless.util.ArmorUtils;
+import org.pgpainless.util.ArmoredOutputStreamFactory;
 
 public final class PGPainless {
 
@@ -78,6 +83,16 @@ public final class PGPainless {
         } else {
             return ArmorUtils.toAsciiArmoredString((PGPPublicKeyRing) key);
         }
+    }
+
+    public static String asciiArmor(@Nonnull PGPSignature signature) throws IOException {
+        ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+        ArmoredOutputStream armoredOut = ArmoredOutputStreamFactory.get(byteOut);
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(armoredOut, true);
+        signature.encode(bcpgOut);
+        bcpgOut.close();
+        armoredOut.close();
+        return byteOut.toString();
     }
 
     /**

--- a/pgpainless-core/src/main/java/org/pgpainless/util/ArmorUtils.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/util/ArmorUtils.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 
 import org.bouncycastle.bcpg.ArmoredInputStream;
 import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.bouncycastle.bcpg.BCPGOutputStream;
 import org.bouncycastle.openpgp.PGPKeyRing;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
@@ -47,22 +48,38 @@ public final class ArmorUtils {
 
     public static String toAsciiArmoredString(PGPSecretKey secretKey) throws IOException {
         MultiMap<String, String> header = keyToHeader(secretKey.getPublicKey());
-        return toAsciiArmoredString(secretKey.getEncoded(), header);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(bytes, true);
+        secretKey.encode(bcpgOut);
+        bcpgOut.close();
+        return toAsciiArmoredString(bytes.toByteArray(), header);
     }
 
     public static String toAsciiArmoredString(PGPPublicKey publicKey) throws IOException {
         MultiMap<String, String> header = keyToHeader(publicKey);
-        return toAsciiArmoredString(publicKey.getEncoded(), header);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(bytes, true);
+        publicKey.encode(bcpgOut);
+        bcpgOut.close();
+        return toAsciiArmoredString(bytes.toByteArray(), header);
     }
 
     public static String toAsciiArmoredString(PGPSecretKeyRing secretKeys) throws IOException {
         MultiMap<String, String> header = keysToHeader(secretKeys);
-        return toAsciiArmoredString(secretKeys.getEncoded(), header);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(bytes, true);
+        secretKeys.encode(bcpgOut);
+        bcpgOut.close();
+        return toAsciiArmoredString(bytes.toByteArray(), header);
     }
 
     public static String toAsciiArmoredString(PGPPublicKeyRing publicKeys) throws IOException {
         MultiMap<String, String> header = keysToHeader(publicKeys);
-        return toAsciiArmoredString(publicKeys.getEncoded(), header);
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        BCPGOutputStream bcpgOut = new BCPGOutputStream(bytes, true);
+        publicKeys.encode(bcpgOut);
+        bcpgOut.close();
+        return toAsciiArmoredString(bytes.toByteArray(), header);
     }
 
     public static String toAsciiArmoredString(PGPSecretKeyRingCollection secretKeyRings) throws IOException {

--- a/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/EncryptDecryptTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/EncryptDecryptTest.java
@@ -18,7 +18,6 @@ import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Set;
 
-import org.bouncycastle.bcpg.ArmoredOutputStream;
 import org.bouncycastle.openpgp.PGPException;
 import org.bouncycastle.openpgp.PGPPublicKeyRing;
 import org.bouncycastle.openpgp.PGPSecretKeyRing;
@@ -45,7 +44,6 @@ import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
 import org.pgpainless.key.util.KeyRingUtils;
 import org.pgpainless.policy.Policy;
-import org.pgpainless.util.ArmoredOutputStreamFactory;
 import org.pgpainless.util.TestAllImplementations;
 
 public class EncryptDecryptTest {
@@ -210,11 +208,7 @@ public class EncryptDecryptTest {
         EncryptionResult metadata = signer.getResult();
 
         Set<PGPSignature> signatureSet = metadata.getDetachedSignatures().get(metadata.getDetachedSignatures().keySet().iterator().next());
-        ByteArrayOutputStream sigOut = new ByteArrayOutputStream();
-        ArmoredOutputStream armorOut = ArmoredOutputStreamFactory.get(sigOut);
-        signatureSet.iterator().next().encode(armorOut);
-        armorOut.close();
-        String armorSig = sigOut.toString();
+        String armorSig = PGPainless.asciiArmor(signatureSet.iterator().next());
 
         // CHECKSTYLE:OFF
         System.out.println(armorSig);

--- a/pgpainless-core/src/test/java/org/pgpainless/key/parsing/UsesNewCTBTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/parsing/UsesNewCTBTest.java
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2022 Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.pgpainless.key.parsing;
+
+import org.bouncycastle.openpgp.PGPPublicKeyRing;
+import org.junit.jupiter.api.Test;
+import org.pgpainless.PGPainless;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UsesNewCTBTest {
+
+    @Test
+    public void testArmoringCertificateUsesNewCTB() throws IOException {
+        final String certUsingOldCTB = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "Version: PGPainless\n" +
+                "Comment: D1A6 6E1A 23B1 82C9 980F  788C FBFC C82A 015E 7330\n" +
+                "Comment: Bob Babbage <bob@openpgp.example>\n" +
+                "\n" +
+                "mQGNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAbQhQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+iQHOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGuQGNBF2lnPIBDADW\n" +
+                "ML9cbGMrp12CtF9b2P6z9TTT74S8iyBOzaSvdGDQY/sUtZXRg21HWamXnn9sSXvI\n" +
+                "DEINOQ6A9QxdxoqWdCHrOuW3ofneYXoG+zeKc4dC86wa1TR2q9vW+RMXSO4uImA+\n" +
+                "Uzula/6k1DogDf28qhCxMwG/i/m9g1c/0aApuDyKdQ1PXsHHNlgd/Dn6rrd5y2AO\n" +
+                "baifV7wIhEJnvqgFXDN2RXGjLeCOHV4Q2WTYPg/S4k1nMXVDwZXrvIsA0YwIMgIT\n" +
+                "86Rafp1qKlgPNbiIlC1g9RY/iFaGN2b4Ir6GDohBQSfZW2+LXoPZuVE/wGlQ01rh\n" +
+                "827KVZW4lXvqsge+wtnWlszcselGATyzqOK9LdHPdZGzROZYI2e8c+paLNDdVPL6\n" +
+                "vdRBUnkCaEkOtl1mr2JpQi5nTU+gTX4IeInC7E+1a9UDF/Y85ybUz8XV8rUnR76U\n" +
+                "qVC7KidNepdHbZjjXCt8/Zo+Tec9JNbYNQB/e9ExmDntmlHEsSEQzFwzj8sxH48A\n" +
+                "EQEAAYkBtgQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJdpZzyAhsMAAoJ\n" +
+                "EPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQMw7+41IL4rVcS\n" +
+                "KhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUrdVaZQanYmtSx\n" +
+                "cVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMVV9zpf3u0k14i\n" +
+                "tcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZgbYn3OWjCPHV\n" +
+                "dTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8/5VK2b0vk/+w\n" +
+                "qMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8AyFAExaEK6Vy\n" +
+                "jP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUCBqWif9RSK4xj\n" +
+                "zRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4ubVrj5KjhX2PV\n" +
+                "NEJd3XZRzaXZE2aAMYkBtgQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJd\n" +
+                "pZzyAhsMAAoJEPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQM\n" +
+                "w7+41IL4rVcSKhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUr\n" +
+                "dVaZQanYmtSxcVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMV\n" +
+                "V9zpf3u0k14itcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZ\n" +
+                "gbYn3OWjCPHVdTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8\n" +
+                "/5VK2b0vk/+wqMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8\n" +
+                "AyFAExaEK6VyjP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUC\n" +
+                "BqWif9RSK4xjzRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4u\n" +
+                "bVrj5KjhX2PVNEJd3XZRzaXZE2Z/MQ==\n" +
+                "=vMTu\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----";
+        final String certUsingNewCTB = "-----BEGIN PGP PUBLIC KEY BLOCK-----\n" +
+                "Version: PGPainless\n" +
+                "Comment: D1A6 6E1A 23B1 82C9 980F  788C FBFC C82A 015E 7330\n" +
+                "Comment: Bob Babbage <bob@openpgp.example>\n" +
+                "\n" +
+                "xsDNBF2lnPIBDAC5cL9PQoQLTMuhjbYvb4Ncuuo0bfmgPRFywX53jPhoFf4Zg6mv\n" +
+                "/seOXpgecTdOcVttfzC8ycIKrt3aQTiwOG/ctaR4Bk/t6ayNFfdUNxHWk4WCKzdz\n" +
+                "/56fW2O0F23qIRd8UUJp5IIlN4RDdRCtdhVQIAuzvp2oVy/LaS2kxQoKvph/5pQ/\n" +
+                "5whqsyroEWDJoSV0yOb25B/iwk/pLUFoyhDG9bj0kIzDxrEqW+7Ba8nocQlecMF3\n" +
+                "X5KMN5kp2zraLv9dlBBpWW43XktjcCZgMy20SouraVma8Je/ECwUWYUiAZxLIlMv\n" +
+                "9CurEOtxUw6N3RdOtLmYZS9uEnn5y1UkF88o8Nku890uk6BrewFzJyLAx5wRZ4F0\n" +
+                "qV/yq36UWQ0JB/AUGhHVPdFf6pl6eaxBwT5GXvbBUibtf8YI2og5RsgTWtXfU7eb\n" +
+                "SGXrl5ZMpbA6mbfhd0R8aPxWfmDWiIOhBufhMCvUHh1sApMKVZnvIff9/0Dca3wb\n" +
+                "vLIwa3T4CyshfT0AEQEAAc0hQm9iIEJhYmJhZ2UgPGJvYkBvcGVucGdwLmV4YW1w\n" +
+                "bGU+wsEOBBMBCgA4AhsDBQsJCAcCBhUKCQgLAgQWAgMBAh4BAheAFiEE0aZuGiOx\n" +
+                "gsmYD3iM+/zIKgFeczAFAl2lnvoACgkQ+/zIKgFeczBvbAv/VNk90a6hG8Od9xTz\n" +
+                "XxH5YRFUSGfIA1yjPIVOnKqhMwps2U+sWE3urL+MvjyQRlyRV8oY9IOhQ5Esm6DO\n" +
+                "ZYrTnE7qVETm1ajIAP2OFChEc55uH88x/anpPOXOJY7S8jbn3naC9qad75BrZ+3g\n" +
+                "9EBUWiy5p8TykP05WSnSxNRt7vFKLfEB4nGkehpwHXOVF0CRNwYle42bg8lpmdXF\n" +
+                "DcCZCi+qEbafmTQzkAqyzS3nCh3IAqq6Y0kBuaKLm2tSNUOlZbD+OHYQNZ5Jix7c\n" +
+                "ZUzs6Xh4+I55NRWl5smrLq66yOQoFPy9jot/Qxikx/wP3MsAzeGaZSEPc0fHp5G1\n" +
+                "6rlGbxQ3vl8/usUV7W+TMEMljgwd5x8POR6HC8EaCDfVnUBCPi/Gv+egLjsIbPJZ\n" +
+                "ZEroiE40e6/UoCiQtlpQB5exPJYSd1Q1txCwueih99PHepsDhmUQKiACszNU+RRo\n" +
+                "zAYau2VdHqnRJ7QYdxHDiH49jPK4NTMyb/tJh2TiIwcmsIpGzsDNBF2lnPIBDADW\n" +
+                "ML9cbGMrp12CtF9b2P6z9TTT74S8iyBOzaSvdGDQY/sUtZXRg21HWamXnn9sSXvI\n" +
+                "DEINOQ6A9QxdxoqWdCHrOuW3ofneYXoG+zeKc4dC86wa1TR2q9vW+RMXSO4uImA+\n" +
+                "Uzula/6k1DogDf28qhCxMwG/i/m9g1c/0aApuDyKdQ1PXsHHNlgd/Dn6rrd5y2AO\n" +
+                "baifV7wIhEJnvqgFXDN2RXGjLeCOHV4Q2WTYPg/S4k1nMXVDwZXrvIsA0YwIMgIT\n" +
+                "86Rafp1qKlgPNbiIlC1g9RY/iFaGN2b4Ir6GDohBQSfZW2+LXoPZuVE/wGlQ01rh\n" +
+                "827KVZW4lXvqsge+wtnWlszcselGATyzqOK9LdHPdZGzROZYI2e8c+paLNDdVPL6\n" +
+                "vdRBUnkCaEkOtl1mr2JpQi5nTU+gTX4IeInC7E+1a9UDF/Y85ybUz8XV8rUnR76U\n" +
+                "qVC7KidNepdHbZjjXCt8/Zo+Tec9JNbYNQB/e9ExmDntmlHEsSEQzFwzj8sxH48A\n" +
+                "EQEAAcLA9gQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJdpZzyAhsMAAoJ\n" +
+                "EPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQMw7+41IL4rVcS\n" +
+                "KhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUrdVaZQanYmtSx\n" +
+                "cVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMVV9zpf3u0k14i\n" +
+                "tcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZgbYn3OWjCPHV\n" +
+                "dTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8/5VK2b0vk/+w\n" +
+                "qMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8AyFAExaEK6Vy\n" +
+                "jP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUCBqWif9RSK4xj\n" +
+                "zRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4ubVrj5KjhX2PV\n" +
+                "NEJd3XZRzaXZE2aAMcLA9gQYAQoAIBYhBNGmbhojsYLJmA94jPv8yCoBXnMwBQJd\n" +
+                "pZzyAhsMAAoJEPv8yCoBXnMw6f8L/26C34dkjBffTzMj5Bdzm8MtF67OYneJ4TQM\n" +
+                "w7+41IL4rVcSKhIhk/3Ud5knaRtP2ef1+5F66h9/RPQOJ5+tvBwhBAcUWSupKnUr\n" +
+                "dVaZQanYmtSxcVV2PL9+QEiNN3tzluhaWO//rACxJ+K/ZXQlIzwQVTpNhfGzAaMV\n" +
+                "V9zpf3u0k14itcv6alKY8+rLZvO1wIIeRZLmU0tZDD5HtWDvUV7rIFI1WuoLb+KZ\n" +
+                "gbYn3OWjCPHVdTrdZ2CqnZbG3SXw6awH9bzRLV9EXkbhIMez0deCVdeo+wFFklh8\n" +
+                "/5VK2b0vk/+wqMJxfpa1lHvJLobzOP9fvrswsr92MA2+k901WeISR7qEzcI0Fdg8\n" +
+                "AyFAExaEK6VyjP7SXGLwvfisw34OxuZr3qmx1Sufu4toH3XrB7QJN8XyqqbsGxUC\n" +
+                "BqWif9RSK4xjzRTe56iPeiSJJOIciMP9i2ldI+KgLycyeDvGoBj0HCLO3gVaBe4u\n" +
+                "bVrj5KjhX2PVNEJd3XZRzaXZE2Z/MQ==\n" +
+                "=6+l9\n" +
+                "-----END PGP PUBLIC KEY BLOCK-----\n";
+
+        PGPPublicKeyRing cert = PGPainless.readKeyRing().publicKeyRing(certUsingOldCTB);
+        String armored = PGPainless.asciiArmor(cert);
+
+        assertEquals(certUsingNewCTB, armored);
+    }
+}

--- a/pgpainless-sop/README.md
+++ b/pgpainless-sop/README.md
@@ -8,8 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 
 [![Spec Revision: 3](https://img.shields.io/badge/Spec%20Revision-3-blue)](https://datatracker.ietf.org/doc/html/draft-dkg-openpgp-stateless-cli-03)
 [![Maven Central](https://badgen.net/maven/v/maven-central/org.pgpainless/pgpainless-sop)](https://search.maven.org/artifact/org.pgpainless/pgpainless-sop)
-[![JavaDoc](https://badgen.net/badge/javadoc/yes/green)](https://pgpainless.org/releases/latest/javadoc/org/pgpainless/sop/package-summary.html)
-[![REUSE status](https://api.reuse.software/badge/github.com/pgpainless/pgpainless)](https://api.reuse.software/info/github.com/pgpainless/pgpainless)
+[![javadoc](https://javadoc.io/badge2/org.pgpainless/pgpainless-sop/javadoc.svg)](https://javadoc.io/doc/org.pgpainless/pgpainless-sop)
 
 Implementation of the Stateless OpenPGP Protocol using PGPainless.
 


### PR DESCRIPTION
This PR changes PGPainless' behavior to (where possible) use the new CTB format.

BC by default makes use of the old CTB in most places, but allows the user to request the new format in some (not all) places.
This PR requests the new CTB format in the following places:

* [x] Public Key Packets (`PGPainless.asciiArmor(certificate)`)
* [x] Secret Key Packets (`PGPainless.asciiArmor(secretKeys)`)
* [x] Standalone Signatures (`PGPainless.asciiArmor(signature)`)
* [ ] Encrypted Data (`PGPainless.encryptAndOrSign()`. see https://github.com/bcgit/bc-java/issues/1010#issuecomment-1037589461 )
* [ ] Compressed Data
* [ ] Literal Data