### PR TITLE
Add new ProducerOption setComment() for Ascii armored EncryptionStreams.

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
@@ -23,6 +23,7 @@ import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
 import org.pgpainless.implementation.ImplementationFactory;
 import org.pgpainless.key.SubkeyIdentifier;
+import org.pgpainless.util.ArmorUtils;
 import org.pgpainless.util.ArmoredOutputStreamFactory;
 import org.pgpainless.util.StreamGeneratorWrapper;
 import org.slf4j.Logger;
@@ -74,6 +75,9 @@ public final class EncryptionStream extends OutputStream {
 
         LOGGER.debug("Wrap encryption output in ASCII armor");
         armorOutputStream = ArmoredOutputStreamFactory.get(outermostStream);
+        if (options.hasComment()) {
+        	ArmorUtils.addCommentHeader(armorOutputStream, options.getComment());
+        }
         outermostStream = armorOutputStream;
     }
 

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
@@ -25,6 +25,7 @@ public final class ProducerOptions {
     private CompressionAlgorithm compressionAlgorithmOverride = PGPainless.getPolicy().getCompressionAlgorithmPolicy()
             .defaultCompressionAlgorithm();
     private boolean asciiArmor = true;
+    private String comment = null;
 
     private ProducerOptions(EncryptionOptions encryptionOptions, SigningOptions signingOptions) {
         this.encryptionOptions = encryptionOptions;
@@ -107,6 +108,40 @@ public final class ProducerOptions {
         return asciiArmor;
     }
 
+    /**
+     * set the comment for header in ascii armored output.
+     * The default value is null, which means no comment header is added.
+     * Multiline comments are possible seperated with '\\n'.
+     *
+     * @param comment 
+     * @return builder
+     */
+    public ProducerOptions setComment(String comment) {
+        if (!asciiArmor) {
+            throw new IllegalArgumentException("Comment can only be set when ASCII armoring is enabled.");
+        }
+        this.comment = comment;
+        return this;
+    }
+
+    /**
+     * Return comment set for header in ascii armored output.
+     *
+     * @return comment
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * Return whether a comment was set (!= null).
+     *
+     * @return comment
+     */
+    public boolean hasComment() {
+        return comment != null;
+    }
+    
     public ProducerOptions setCleartextSigned() {
         if (signingOptions == null) {
             throw new IllegalArgumentException("Signing Options cannot be null if cleartext signing is enabled.");
@@ -185,7 +220,7 @@ public final class ProducerOptions {
      * Set the format of the literal data packet.
      * Defaults to {@link StreamEncoding#BINARY}.
      *
-     * @see <a href="https://datatracker.ietf.org/doc/html/rfc4880#section-5.9">RFC4880 ยง5.9. Literal Data Packet</a>
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc4880#section-5.9">RFC4880 ง5.9. Literal Data Packet</a>
      *
      * @param encoding encoding
      * @return this

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
@@ -111,9 +111,9 @@ public final class ProducerOptions {
     /**
      * set the comment for header in ascii armored output.
      * The default value is null, which means no comment header is added.
-     * Multiline comments are possible seperated with '\\n'.
+     * Multiline comments are possible using '\\n'.
      *
-     * @param comment 
+     * @param comment comment header text
      * @return builder
      */
     public ProducerOptions setComment(String comment) {
@@ -141,7 +141,7 @@ public final class ProducerOptions {
     public boolean hasComment() {
         return comment != null;
     }
-    
+
     public ProducerOptions setCleartextSigned() {
         if (signingOptions == null) {
             throw new IllegalArgumentException("Signing Options cannot be null if cleartext signing is enabled.");

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
@@ -220,7 +220,7 @@ public final class ProducerOptions {
      * Set the format of the literal data packet.
      * Defaults to {@link StreamEncoding#BINARY}.
      *
-     * @see <a href="https://datatracker.ietf.org/doc/html/rfc4880#section-5.9">RFC4880 ง5.9. Literal Data Packet</a>
+     * @see <a href="https://datatracker.ietf.org/doc/html/rfc4880#section-5.9">RFC4880 ยง5.9. Literal Data Packet</a>
      *
      * @param encoding encoding
      * @return this

--- a/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
@@ -135,7 +135,7 @@ public class Encrypt {
      * She encrypts the message to both bobs certificate and her own.
      * A comment header with the text "This comment was added using options." is added 
      * using the fluent ProducerOption syntax.
-     *  
+     *
      * Bob subsequently decrypts the message using his key.
      */
     @Test

--- a/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
@@ -129,13 +129,14 @@ public class Encrypt {
 
         assertEquals(message, plaintext.toString());
     }
-    
+
     /**
      * In this example, Alice is sending a signed and encrypted message to Bob.
-     * She signs the message using her key and then encrypts the message to both bobs certificate and her own.
-     *
-     * Bob subsequently decrypts the message using his key and verifies that the message was signed by Alice using
-     * her certificate.
+     * She encrypts the message to both bobs certificate and her own.
+     * A comment header with the text "This comment was added using options." is added 
+     * using the fluent ProducerOption syntax.
+     *  
+     * Bob subsequently decrypts the message using his key.
      */
     @Test
     public void encryptWithCommentHeader() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IOException {
@@ -170,11 +171,11 @@ public class Encrypt {
         encryptor.close();
         String encryptedMessage = ciphertext.toString();
 
-        // comment should be third line after "BEGIN PGP" and "Version:"
-        assertEquals(encryptedMessage.split("\n")[2].trim(), "Comment: "+comment);
+        // check that comment header was added after "BEGIN PGP" and "Version:"
+        assertEquals(encryptedMessage.split("\n")[2].trim(), "Comment: " + comment);
 
         // also test, that decryption still works...
-        
+
         // Decrypt and verify signatures
         DecryptionStream decryptor = PGPainless.decryptAndOrVerify()
                 .onInputStream(new ByteArrayInputStream(encryptedMessage.getBytes(StandardCharsets.UTF_8)))
@@ -194,5 +195,5 @@ public class Encrypt {
         assertEquals(message, plaintext.toString());
     }
 
-    
+
 }

--- a/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
@@ -133,7 +133,7 @@ public class Encrypt {
     /**
      * In this example, Alice is sending a signed and encrypted message to Bob.
      * She encrypts the message to both bobs certificate and her own.
-     * A comment header with the text "This comment was added using options." is added 
+     * A comment header with the text "This comment was added using options." is added
      * using the fluent ProducerOption syntax.
      *
      * Bob subsequently decrypts the message using his key.


### PR DESCRIPTION
This Pull-Request adds a new ProducerOption "setComment(comment)", which can be used in combination with ascii armored output streams.

```
        EncryptionStream encryptionStream = PGPainless.encryptAndOrSign()
                .onOutputStream(outputStream)
                .withOptions(
                        ProducerOptions.signAndEncrypt(
                                ...
                        ).setAsciiArmor(true) // Ascii armor or not
                        .setComment("My humble comment.")
                );
```

In the generated output file the first lines look like this:

```
-----BEGIN PGP MESSAGE-----
Version: PGPainless
Comment: My humble comment.
...
```

A new testcase org.pgpainless.example.Encrypt::encryptWithCommentHeader() was added to check the functionality.
