### PR TITLE
FIX support of multiline comments in ProducerOption.setComment().

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
@@ -79,7 +79,7 @@ public final class EncryptionStream extends OutputStream {
             String[] commentLines = options.getComment().split("\n");
             for (String commentLine : commentLines) {
             	if (!commentLine.trim().isEmpty()) {
-            		ArmorUtils.addCommentHeader(armorOutputStream, commentLine);
+            		ArmorUtils.addCommentHeader(armorOutputStream, commentLine.trim());
             	}
             }
         }

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
@@ -76,7 +76,12 @@ public final class EncryptionStream extends OutputStream {
         LOGGER.debug("Wrap encryption output in ASCII armor");
         armorOutputStream = ArmoredOutputStreamFactory.get(outermostStream);
         if (options.hasComment()) {
-        	ArmorUtils.addCommentHeader(armorOutputStream, options.getComment());
+            String[] commentLines = options.getComment().split("\n");
+            for (String commentLine : commentLines) {
+            	if (!commentLine.trim().isEmpty()) {
+            		ArmorUtils.addCommentHeader(armorOutputStream, commentLine);
+            	}
+            }
         }
         outermostStream = armorOutputStream;
     }

--- a/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/example/Encrypt.java
@@ -133,8 +133,7 @@ public class Encrypt {
     /**
      * In this example, Alice is sending a signed and encrypted message to Bob.
      * She encrypts the message to both bobs certificate and her own.
-     * A comment header with the text "This comment was added using options." is added
-     * using the fluent ProducerOption syntax.
+     * A multiline comment header is added using the fluent ProducerOption syntax.
      *
      * Bob subsequently decrypts the message using his key.
      */
@@ -152,7 +151,13 @@ public class Encrypt {
 
         // plaintext message to encrypt
         String message = "Hello, World!\n";
-        String comment = "This comment was added using options.";
+        String[] comments = {
+        		"This comment was added using options.",
+        		"And it has three lines.",
+        		" ",
+        		"Empty lines are skipped."
+        };
+        String comment = comments[0] + "\n" + comments[1] + "\n" + comments[2] + "\n" + comments[3];
         ByteArrayOutputStream ciphertext = new ByteArrayOutputStream();
         // Encrypt and sign
         EncryptionStream encryptor = PGPainless.encryptAndOrSign()
@@ -172,7 +177,9 @@ public class Encrypt {
         String encryptedMessage = ciphertext.toString();
 
         // check that comment header was added after "BEGIN PGP" and "Version:"
-        assertEquals(encryptedMessage.split("\n")[2].trim(), "Comment: " + comment);
+        assertEquals(encryptedMessage.split("\n")[2].trim(), "Comment: " + comments[0]);
+        assertEquals(encryptedMessage.split("\n")[3].trim(), "Comment: " + comments[1]);
+        assertEquals(encryptedMessage.split("\n")[4].trim(), "Comment: " + comments[3]);
 
         // also test, that decryption still works...
 


### PR DESCRIPTION
This is a FIX for PR #254 

In the documentation of ProducerOption.setComment() I stated, that multilne comments are possible using '\\n'.
But that was wrong.
I mixed up ArmoredOutputStreamFactory.setComment() and ArmoredOutputStream.addComment().

This PR adds the described multiline functionality as described.
Empty lines are not added as comment.


