### PR TITLE
Fix/armored header multiple uids

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ There are some predefined key archetypes, but it is possible to fully customize 
                                         KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE)
                 ).addUserId("Juliet <juliet@montague.lit>")
                 .addUserId("xmpp:juliet@capulet.lit")
-                .setPassphrase("romeo_oh_Romeo<3")
+                .setPassphrase(Passphrase.fromPassword("romeo_oh_Romeo<3"))
                 .build();
 ```
 


### PR DESCRIPTION
The current implementation of ArmorUtils only serialize one identity in the header comment. This has not to be the primary identity, just the one that happens to be the first in the iterator.
This change fixes that behaviour, resulting in all identities being serialized in the comments.
Furthermore, one example in the README is not working as the Passphrase wrapper class is not used.