### PR TITLE
Implement configuration option for SignerUserId subpacket verification level.

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/policy/Policy.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/policy/Policy.java
@@ -42,6 +42,25 @@ public final class Policy {
 
     private AlgorithmSuite keyGenerationAlgorithmSuite = AlgorithmSuite.getDefaultAlgorithmSuite();
 
+    // Signers User-ID is soon to be deprecated.
+    private SignerUserIdValidationLevel signerUserIdValidationLevel = SignerUserIdValidationLevel.DISABLED;
+
+    public enum SignerUserIdValidationLevel {
+        /**
+         * PGPainless will verify {@link org.bouncycastle.bcpg.sig.SignerUserID} subpackets in signatures strictly.
+         * This means, that signatures with Signer's User-ID subpackets containing a value that does not match the signer key's
+         * user-id exactly, will be rejected.
+         * E.g. Signer's user-id "alice@pgpainless.org", User-ID: "Alice &lt;alice@pgpainless.org&gt;" does not
+         * match exactly and is therefore rejected.
+         */
+        STRICT,
+
+        /**
+         * PGPainless will ignore {@link org.bouncycastle.bcpg.sig.SignerUserID} subpackets on signature.
+         */
+        DISABLED
+    }
+
     Policy() {
     }
 
@@ -467,5 +486,30 @@ public final class Policy {
      */
     public void setKeyGenerationAlgorithmSuite(@Nonnull AlgorithmSuite algorithmSuite) {
         this.keyGenerationAlgorithmSuite = algorithmSuite;
+    }
+
+    /**
+     * Return the level of validation PGPainless shall do on {@link org.bouncycastle.bcpg.sig.SignerUserID} subpackets.
+     * By default, this value is {@link SignerUserIdValidationLevel#DISABLED}.
+     *
+     * @return the level of validation
+     */
+    public SignerUserIdValidationLevel getSignerUserIdValidationLevel() {
+        return signerUserIdValidationLevel;
+    }
+
+    /**
+     * Specify, how {@link org.bouncycastle.bcpg.sig.SignerUserID} subpackets on signatures shall be validated.
+     *
+     * @param signerUserIdValidationLevel level of verification PGPainless shall do on
+     * {@link org.bouncycastle.bcpg.sig.SignerUserID} subpackets.
+     * @return policy instance
+     */
+    public Policy setSignerUserIdValidationLevel(SignerUserIdValidationLevel signerUserIdValidationLevel) {
+        if (signerUserIdValidationLevel == null) {
+            throw new NullPointerException("SignerUserIdValidationLevel cannot be null.");
+        }
+        this.signerUserIdValidationLevel = signerUserIdValidationLevel;
+        return this;
     }
 }

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/consumer/CertificateValidator.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/consumer/CertificateValidator.java
@@ -143,7 +143,7 @@ public final class CertificateValidator {
 
         // Specific signer user-id
         SignerUserID signerUserID = SignatureSubpacketsUtil.getSignerUserID(signature);
-        if (signerUserID != null) {
+        if (signerUserID != null && policy.getSignerUserIdValidationLevel() == Policy.SignerUserIdValidationLevel.STRICT) {
             List<PGPSignature> signerUserIdSigs = userIdSignatures.get(signerUserID.getID());
             if (signerUserIdSigs == null || signerUserIdSigs.isEmpty()) {
                 throw new SignatureValidationException("Signature was allegedly made by user-id '" + signerUserID.getID() +


### PR DESCRIPTION
By default we ignore SignerUserId subpackets on signatures.
This behavior can be changed by calling Policy.setSignerUserIdValidationLevel().
Right now, STRICT and DISABLED are available as options, but it may make sense to implement
another option PARTIALLY, which will accept signatures made by key with user-id 'A <foo@bar>'
but where the sig contains a signer user id of value 'foo@bar' for example.

STRICT will reject a signature made by key 'A <foo@bar>' if the signer's user-id does not exactly match the keys user-id.