### PR TITLE
Add ProducerOptions.applyCRLFEncoding()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ SPDX-License-Identifier: CC0-1.0
 
 ## 1.1.5-SNAPSHOT
 - SOP encrypt: match signature type when using `encrypt --as=` option
-- `ProducerOptions.setEncoding()`: The encoding is henceforth only considered metadata and will no longer trigger CRLF encoding
+- `ProducerOptions.setEncoding()`: The encoding is henceforth only considered metadata and will no longer trigger CRLF encoding.
   - This fixes broken signature generation for mismatching (`StreamEncoding`,`DocumentSignatureType`) tuples.
-  - Applications that rely on CRLF-encoding must now apply that encoding themselves (see [#264](https://github.com/pgpainless/pgpainless/issues/264#issuecomment-1083206738) for details).
+  - Applications that rely on CRLF-encoding can request PGPainless to apply this encoding by calling `ProducerOptions.applyCRLFEncoding(true)`.
 
 ## 1.1.4
 - Add utility method `KeyRingUtils.removeSecretKey()` to remove secret key part from key ring

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/CRLFGeneratorStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/CRLFGeneratorStream.java
@@ -12,21 +12,6 @@ import java.io.OutputStream;
 
 /**
  * {@link OutputStream} which applies CR-LF encoding of its input data, based on the desired {@link StreamEncoding}.
- *
- *
- * If you need PGPainless to CRLF encode signed data for you, you could do the following:
- * {@code
- * <pre>
- *     InputStream plaintext = ...
- *     EncryptionStream signerOrEncryptor = PGPainless.signAndOrEncrypt(...);
- *     CRLFGeneratorStream crlfOut = new CRLFGeneratorStream(signerOrEncryptor, streamEncoding);
- *
- *     Streams.pipeAll(plaintext, crlfOut);
- *     crlfOut.close;
- *
- *     EncryptionResult result = signerOrEncryptor.getResult();
- * </pre>
- * }
  * This implementation originates from the Bouncy Castle library.
  */
 public class CRLFGeneratorStream extends OutputStream {

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
@@ -19,7 +19,8 @@ public final class ProducerOptions {
     private final SigningOptions signingOptions;
     private String fileName = "";
     private Date modificationDate = PGPLiteralData.NOW;
-    private StreamEncoding streamEncoding = StreamEncoding.BINARY;
+    private StreamEncoding encodingField = StreamEncoding.BINARY;
+    private boolean applyCRLFEncoding = false;
     private boolean cleartextSigned = false;
 
     private CompressionAlgorithm compressionAlgorithmOverride = PGPainless.getPolicy().getCompressionAlgorithmPolicy()
@@ -223,8 +224,11 @@ public final class ProducerOptions {
     }
 
     /**
-     * Set the format of the literal data packet.
+     * Set format metadata field of the literal data packet.
      * Defaults to {@link StreamEncoding#BINARY}.
+     *
+     * This does not change the encoding of the wrapped data itself.
+     * To apply CR/LF encoding to your input data before processing, use {@link #applyCRLFEncoding(boolean)} instead.
      *
      * @see <a href="https://datatracker.ietf.org/doc/html/rfc4880#section-5.9">RFC4880 §5.9. Literal Data Packet</a>
      *
@@ -235,12 +239,37 @@ public final class ProducerOptions {
      */
     @Deprecated
     public ProducerOptions setEncoding(@Nonnull StreamEncoding encoding) {
-        this.streamEncoding = encoding;
+        this.encodingField = encoding;
         return this;
     }
 
     public StreamEncoding getEncoding() {
-        return streamEncoding;
+        return encodingField;
+    }
+
+    /**
+     * Apply special encoding of line endings to the input data.
+     * By default, this is set to <pre>false</pre>, which means that the data is not altered.
+     *
+     * Setting it to <pre>true</pre> will change the line endings to CR/LF.
+     * Note: The encoding will not be reversed when decrypting, so applying CR/LF encoding will result in
+     * the identity "decrypt(encrypt(data)) == data == verify(sign(data))".
+     *
+     * @param applyCRLFEncoding apply crlf encoding
+     * @return this
+     */
+    public ProducerOptions applyCRLFEncoding(boolean applyCRLFEncoding) {
+        this.applyCRLFEncoding = applyCRLFEncoding;
+        return this;
+    }
+
+    /**
+     * Return the input encoding that will be applied before signing / encryption.
+     *
+     * @return input encoding
+     */
+    public boolean isApplyCRLFEncoding() {
+        return applyCRLFEncoding;
     }
 
     /**

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/ProducerOptions.java
@@ -249,17 +249,16 @@ public final class ProducerOptions {
 
     /**
      * Apply special encoding of line endings to the input data.
-     * By default, this is set to <pre>false</pre>, which means that the data is not altered.
+     * By default, this is disabled, which means that the data is not altered.
      *
-     * Setting it to <pre>true</pre> will change the line endings to CR/LF.
+     * Enabling it will change the line endings to CR/LF.
      * Note: The encoding will not be reversed when decrypting, so applying CR/LF encoding will result in
      * the identity "decrypt(encrypt(data)) == data == verify(sign(data))".
      *
-     * @param applyCRLFEncoding apply crlf encoding
      * @return this
      */
-    public ProducerOptions applyCRLFEncoding(boolean applyCRLFEncoding) {
-        this.applyCRLFEncoding = applyCRLFEncoding;
+    public ProducerOptions applyCRLFEncoding() {
+        this.applyCRLFEncoding = true;
         return this;
     }
 

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/SignatureGenerationStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/SignatureGenerationStream.java
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2022 Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.pgpainless.encryption_signing;
+
+import org.bouncycastle.openpgp.PGPSignatureGenerator;
+import org.pgpainless.key.SubkeyIdentifier;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.io.OutputStream;
+
+class SignatureGenerationStream extends OutputStream {
+
+    private final OutputStream wrapped;
+    private final SigningOptions options;
+
+    SignatureGenerationStream(OutputStream wrapped, SigningOptions signingOptions) {
+        this.wrapped = wrapped;
+        this.options = signingOptions;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        wrapped.write(b);
+        if (options == null || options.getSigningMethods().isEmpty()) {
+            return;
+        }
+
+        for (SubkeyIdentifier signingKey : options.getSigningMethods().keySet()) {
+            SigningOptions.SigningMethod signingMethod = options.getSigningMethods().get(signingKey);
+            PGPSignatureGenerator signatureGenerator = signingMethod.getSignatureGenerator();
+            byte asByte = (byte) (b & 0xff);
+            signatureGenerator.update(asByte);
+        }
+    }
+
+    @Override
+    public void write(@Nonnull byte[] buffer) throws IOException {
+        write(buffer, 0, buffer.length);
+    }
+
+    @Override
+    public void write(@Nonnull byte[] buffer, int off, int len) throws IOException {
+        wrapped.write(buffer, 0, len);
+        if (options == null || options.getSigningMethods().isEmpty()) {
+            return;
+        }
+        for (SubkeyIdentifier signingKey : options.getSigningMethods().keySet()) {
+            SigningOptions.SigningMethod signingMethod = options.getSigningMethods().get(signingKey);
+            PGPSignatureGenerator signatureGenerator = signingMethod.getSignatureGenerator();
+            signatureGenerator.update(buffer, 0, len);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        wrapped.close();
+    }
+}

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/SignatureGenerationStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/SignatureGenerationStream.java
@@ -11,6 +11,9 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.OutputStream;
 
+/**
+ * OutputStream which has the task of updating signature generators for written data.
+ */
 class SignatureGenerationStream extends OutputStream {
 
     private final OutputStream wrapped;

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/SignatureGenerationStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/SignatureGenerationStream.java
@@ -8,6 +8,7 @@ import org.bouncycastle.openpgp.PGPSignatureGenerator;
 import org.pgpainless.key.SubkeyIdentifier;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -19,7 +20,7 @@ class SignatureGenerationStream extends OutputStream {
     private final OutputStream wrapped;
     private final SigningOptions options;
 
-    SignatureGenerationStream(OutputStream wrapped, SigningOptions signingOptions) {
+    SignatureGenerationStream(@Nonnull OutputStream wrapped, @Nullable SigningOptions signingOptions) {
         this.wrapped = wrapped;
         this.options = signingOptions;
     }

--- a/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/CanonicalizedDataEncryptionTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/CanonicalizedDataEncryptionTest.java
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package investigations;
+package org.pgpainless.decryption_verification;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -34,9 +34,6 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.DocumentSignatureType;
 import org.pgpainless.algorithm.HashAlgorithm;
 import org.pgpainless.algorithm.StreamEncoding;
-import org.pgpainless.decryption_verification.ConsumerOptions;
-import org.pgpainless.decryption_verification.DecryptionStream;
-import org.pgpainless.decryption_verification.OpenPgpMetadata;
 import org.pgpainless.encryption_signing.CRLFGeneratorStream;
 import org.pgpainless.encryption_signing.EncryptionOptions;
 import org.pgpainless.encryption_signing.EncryptionStream;
@@ -120,9 +117,11 @@ public class CanonicalizedDataEncryptionTest {
         // CHECKSTYLE:ON
     }
 
+    // NO CR/LF ENCODING PRIOR TO PROCESSING
+
     @Test
-    public void binaryDataBinarySig() throws PGPException, IOException {
-        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.BINARY);
+    public void noInputEncodingBinaryDataBinarySig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.BINARY, false);
         OpenPgpMetadata metadata = decryptAndVerify(msg);
 
         if (!metadata.isVerified()) {
@@ -135,8 +134,8 @@ public class CanonicalizedDataEncryptionTest {
     }
 
     @Test
-    public void binaryDataTextSig() throws PGPException, IOException {
-        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.BINARY);
+    public void noInputEncodingBinaryDataTextSig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.BINARY, false);
         OpenPgpMetadata metadata = decryptAndVerify(msg);
 
         if (!metadata.isVerified()) {
@@ -149,8 +148,8 @@ public class CanonicalizedDataEncryptionTest {
     }
 
     @Test
-    public void textDataBinarySig() throws PGPException, IOException {
-        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.TEXT);
+    public void noInputEncodingTextDataBinarySig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.TEXT, false);
         OpenPgpMetadata metadata = decryptAndVerify(msg);
 
         if (!metadata.isVerified()) {
@@ -163,8 +162,8 @@ public class CanonicalizedDataEncryptionTest {
     }
 
     @Test
-    public void textDataTextSig() throws PGPException, IOException {
-        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.TEXT);
+    public void noInputEncodingTextDataTextSig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.TEXT, false);
         OpenPgpMetadata metadata = decryptAndVerify(msg);
 
         if (!metadata.isVerified()) {
@@ -177,8 +176,8 @@ public class CanonicalizedDataEncryptionTest {
     }
 
     @Test
-    public void utf8DataBinarySig() throws PGPException, IOException {
-        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.UTF8);
+    public void noInputEncodingUtf8DataBinarySig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.UTF8, false);
         OpenPgpMetadata metadata = decryptAndVerify(msg);
 
         if (!metadata.isVerified()) {
@@ -191,8 +190,23 @@ public class CanonicalizedDataEncryptionTest {
     }
 
     @Test
-    public void utf8DataTextSig() throws PGPException, IOException {
-        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.UTF8);
+    public void noInputEncodingUtf8DataTextSig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.UTF8, false);
+        OpenPgpMetadata metadata = decryptAndVerify(msg);
+
+        if (!metadata.isVerified()) {
+            // CHECKSTYLE:OFF
+            System.out.println("Not verified. Session-Key: " + metadata.getSessionKey());
+            System.out.println(msg);
+            // CHECKSTYLE:ON
+            fail();
+        }
+    }
+    // APPLY CR/LF ENCODING PRIOR TO PROCESSING
+
+    @Test
+    public void inputEncodingBinaryDataBinarySig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.BINARY, true);
         OpenPgpMetadata metadata = decryptAndVerify(msg);
 
         if (!metadata.isVerified()) {
@@ -204,7 +218,80 @@ public class CanonicalizedDataEncryptionTest {
         }
     }
 
-    private String encryptAndSign(String message, DocumentSignatureType sigType, StreamEncoding dataFormat)
+    @Test
+    public void inputEncodingBinaryDataTextSig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.BINARY, true);
+        OpenPgpMetadata metadata = decryptAndVerify(msg);
+
+        if (!metadata.isVerified()) {
+            // CHECKSTYLE:OFF
+            System.out.println("Not verified. Session-Key: " + metadata.getSessionKey());
+            System.out.println(msg);
+            // CHECKSTYLE:ON
+            fail();
+        }
+    }
+
+    @Test
+    public void inputEncodingTextDataBinarySig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.TEXT, true);
+        OpenPgpMetadata metadata = decryptAndVerify(msg);
+
+        if (!metadata.isVerified()) {
+            // CHECKSTYLE:OFF
+            System.out.println("Not verified. Session-Key: " + metadata.getSessionKey());
+            System.out.println(msg);
+            // CHECKSTYLE:ON
+            fail();
+        }
+    }
+
+    @Test
+    public void inputEncodingTextDataTextSig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.TEXT, true);
+        OpenPgpMetadata metadata = decryptAndVerify(msg);
+
+        if (!metadata.isVerified()) {
+            // CHECKSTYLE:OFF
+            System.out.println("Not verified. Session-Key: " + metadata.getSessionKey());
+            System.out.println(msg);
+            // CHECKSTYLE:ON
+            fail();
+        }
+    }
+
+    @Test
+    public void inputEncodingUtf8DataBinarySig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.BINARY_DOCUMENT, StreamEncoding.UTF8, true);
+        OpenPgpMetadata metadata = decryptAndVerify(msg);
+
+        if (!metadata.isVerified()) {
+            // CHECKSTYLE:OFF
+            System.out.println("Not verified. Session-Key: " + metadata.getSessionKey());
+            System.out.println(msg);
+            // CHECKSTYLE:ON
+            fail();
+        }
+    }
+
+    @Test
+    public void inputEncodingUtf8DataTextSig() throws PGPException, IOException {
+        String msg = encryptAndSign(message, DocumentSignatureType.CANONICAL_TEXT_DOCUMENT, StreamEncoding.UTF8, true);
+        OpenPgpMetadata metadata = decryptAndVerify(msg);
+
+        if (!metadata.isVerified()) {
+            // CHECKSTYLE:OFF
+            System.out.println("Not verified. Session-Key: " + metadata.getSessionKey());
+            System.out.println(msg);
+            // CHECKSTYLE:ON
+            fail();
+        }
+    }
+
+    private String encryptAndSign(String message,
+                                  DocumentSignatureType sigType,
+                                  StreamEncoding dataFormat,
+                                  boolean applyCRLFEncoding)
             throws PGPException, IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
 
@@ -218,6 +305,7 @@ public class CanonicalizedDataEncryptionTest {
                                         .addInlineSignature(SecretKeyRingProtector.unprotectedKeys(), secretKeys, sigType)
                         )
                         .setEncoding(dataFormat)
+                        .applyCRLFEncoding(applyCRLFEncoding)
                 );
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream(message.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Enabling it will automatically apply CRLF encoding to input data.
Further, disentangle signing from the encryption stream.

This is a followup fix for #264 