### PR TITLE
Performance Improvements

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/CRLFGeneratorStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/CRLFGeneratorStream.java
@@ -46,4 +46,10 @@ public class CRLFGeneratorStream extends OutputStream {
         }
         crlfOut.close();
     }
+
+    @Override
+    public void flush() throws IOException {
+        super.flush();
+        crlfOut.flush();
+    }
 }

--- a/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/encryption_signing/EncryptionStream.java
@@ -4,6 +4,7 @@
 
 package org.pgpainless.encryption_signing;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
@@ -182,7 +183,11 @@ public final class EncryptionStream extends OutputStream {
     }
 
     public void prepareInputEncoding() {
-        CRLFGeneratorStream crlfGeneratorStream = new CRLFGeneratorStream(outermostStream,
+        // By buffering here, we drastically improve performance
+        // Reason is that CRLFGeneratorStream only implements write(int), so we need BufferedOutputStream to
+        // "convert" to write(buf) calls again
+        BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outermostStream);
+        CRLFGeneratorStream crlfGeneratorStream = new CRLFGeneratorStream(bufferedOutputStream,
                 options.isApplyCRLFEncoding() ? StreamEncoding.UTF8 : StreamEncoding.BINARY);
         outermostStream = crlfGeneratorStream;
     }

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/ArmorImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/ArmorImpl.java
@@ -4,6 +4,7 @@
 
 package org.pgpainless.sop;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -28,8 +29,11 @@ public class ArmorImpl implements Armor {
         return new Ready() {
             @Override
             public void writeTo(OutputStream outputStream) throws IOException {
-                ArmoredOutputStream armor = ArmoredOutputStreamFactory.get(outputStream);
+                // By buffering the output stream, we can improve performance drastically
+                BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);
+                ArmoredOutputStream armor = ArmoredOutputStreamFactory.get(bufferedOutputStream);
                 Streams.pipeAll(data, armor);
+                bufferedOutputStream.flush();
                 armor.close();
             }
         };

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/DearmorImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/DearmorImpl.java
@@ -4,6 +4,7 @@
 
 package org.pgpainless.sop;
 
+import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -22,7 +23,9 @@ public class DearmorImpl implements Dearmor {
 
             @Override
             public void writeTo(OutputStream outputStream) throws IOException {
-                Streams.pipeAll(decoder, outputStream);
+                BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(outputStream);
+                Streams.pipeAll(decoder, bufferedOutputStream);
+                bufferedOutputStream.flush();
                 decoder.close();
             }
         };


### PR DESCRIPTION
@teythoon created a [new benchmarking tool for the SOP interface](https://tests.sequoia-pgp.org/bench.html) which revealed that PGPainless is suffering from severe performance issues.

I did some digging and figured out that there were some issues caused by Streams:
The CRLFGeneratorStream only implements `write(int)`, which caused that for wrapped streams (especially encryption / signing streams) write(int) was called instead of their faster buffer-writing methods.

This has been fixed by inserting a BufferedInputStream in the EncryptionStream class.

Further, similar issues were present in the sop armor implementation (ArmoredOutputStream does not implement write(buf)).