### PR TITLE
Correct method name (typo)

### DIFF
--- a/docs/source/pgpainless-sop/quickstart.md
+++ b/docs/source/pgpainless-sop/quickstart.md
@@ -209,7 +209,7 @@ byte[] ciphertext = ...; // the encrypted message
 
 ReadyWithResult<DecryptionResult> readyWithResult = sop.decrypt()
         .withKey(bobKey)
-        .verifyWith(aliceCert)
+        .verifyWithCert(aliceCert)
         .withKeyPassword("password123") // if decryption key is protected
         .ciphertext(ciphertext);
 ```


### PR DESCRIPTION
Correct `verifyWith()` to `verifyWithCert()` in the documentation.
A `verifyWith()` method does not exist. It's properly a small typo.