### PR TITLE
Fixed redundant dot in the exception message

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStream.java
@@ -970,7 +970,7 @@ public class OpenPgpMessageInputStream extends DecryptionStream {
                 LOGGER.debug("No suitable certificate for verification of signature by key " + KeyIdUtil.formatKeyId(keyId) + " found.");
                 inbandSignaturesWithMissingCert.add(new SignatureVerification.Failure(
                         new SignatureVerification(signature, null),
-                        new SignatureValidationException("Missing verification key.")));
+                        new SignatureValidationException("Missing verification key")));
             }
         }
 


### PR DESCRIPTION
A small fix 

![image](https://user-images.githubusercontent.com/2863246/213991168-61f785f5-f9e4-4c1f-82c6-2813b34ac5a1.png)

It prevents using Regex for matching.

```kotlin
keyIdOfSigningKeys.addAll(invalidSignatureFailures.filter {
              it.validationException.message == "Missing verification key"
            }.mapNotNull { it.signatureVerification.signature.keyID })
```

instead of

```kotlin
keyIdOfSigningKeys.addAll(invalidSignatureFailures.filter {
              it.validationException.message?.matches("Missing verification key.?".toRegex()) == true
            }.mapNotNull { it.signatureVerification.signature.keyID })
```