### PR TITLE
Add ConsumerOptions.setRequireValidDecryptionKey()

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/ConsumerOptions.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/ConsumerOptions.java
@@ -37,6 +37,7 @@ import org.pgpainless.util.SessionKey;
 public class ConsumerOptions {
 
     private boolean ignoreMDCErrors = false;
+    private boolean requireValidDecryptionKey = true;
     private boolean forceNonOpenPgpData = false;
 
     private Date verifyNotBefore = null;
@@ -389,6 +390,15 @@ public class ConsumerOptions {
      */
     boolean isIgnoreMDCErrors() {
         return ignoreMDCErrors;
+    }
+
+    public ConsumerOptions setRequireValidDecryptionKey(boolean requireValidDecryptionKey) {
+        this.requireValidDecryptionKey = requireValidDecryptionKey;
+        return this;
+    }
+
+    boolean isRequireValidDecryptionKey() {
+        return requireValidDecryptionKey;
     }
 
     /**

--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStream.java
@@ -691,15 +691,19 @@ public class OpenPgpMessageInputStream extends DecryptionStream {
                 continue;
             }
 
-            KeyRingInfo info = new KeyRingInfo(secretKeys, policy, new Date());
-            List<PGPPublicKey> encryptionKeys = info.getEncryptionSubkeys(EncryptionPurpose.ANY);
-            for (PGPPublicKey key : encryptionKeys) {
-                if (key.getKeyID() == keyID) {
-                    return secretKeys;
+            if (options.isRequireValidDecryptionKey()) {
+                KeyRingInfo info = new KeyRingInfo(secretKeys, policy, new Date());
+                List<PGPPublicKey> encryptionKeys = info.getEncryptionSubkeys(EncryptionPurpose.ANY);
+                for (PGPPublicKey key : encryptionKeys) {
+                    if (key.getKeyID() == keyID) {
+                        return secretKeys;
+                    }
                 }
+                LOGGER.debug("Subkey " + Long.toHexString(keyID) + " cannot be used for decryption.");
+            } else {
+                return secretKeys;
             }
 
-            LOGGER.debug("Subkey " + Long.toHexString(keyID) + " cannot be used for decryption.");
         }
         return null;
     }


### PR DESCRIPTION
This is true by default.

Consumers can use this method to overwrite the default behavior, allowing successfuly decryption of messages using expired / revoked / unbound decryption keys.

Proposed as a workaround for #365 