### PR TITLE
OpenPgpMessageInputStream: Return -1 instead of throwing MalformedOpe…

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStream.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStream.java
@@ -744,6 +744,7 @@ public class OpenPgpMessageInputStream extends DecryptionStream {
             throws IOException {
         if (nestedInputStream == null) {
             if (packetInputStream != null) {
+                syntaxVerifier.next(InputSymbol.EndOfSequence);
                 syntaxVerifier.assertValid();
             }
             return -1;
@@ -774,6 +775,7 @@ public class OpenPgpMessageInputStream extends DecryptionStream {
         super.close();
         if (closed) {
             if (packetInputStream != null) {
+                syntaxVerifier.next(InputSymbol.EndOfSequence);
                 syntaxVerifier.assertValid();
             }
             return;

--- a/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/syntax_check/OpenPgpMessageSyntax.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/decryption_verification/syntax_check/OpenPgpMessageSyntax.java
@@ -132,6 +132,10 @@ public class OpenPgpMessageSyntax implements Syntax {
     @Nonnull
     Transition fromValid(@Nonnull InputSymbol input, @Nullable StackSymbol stackItem)
             throws MalformedOpenPgpMessageException {
+        if (input == InputSymbol.EndOfSequence) {
+            // allow subsequent read() calls.
+            return new Transition(State.Valid);
+        }
         // There is no applicable transition rule out of Valid
         throw new MalformedOpenPgpMessageException(State.Valid, input, stackItem);
     }

--- a/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStreamTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/OpenPgpMessageInputStreamTest.java
@@ -34,6 +34,7 @@ import org.bouncycastle.openpgp.PGPSignature;
 import org.bouncycastle.util.io.Streams;
 import org.junit.JUtils;
 import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -650,6 +651,22 @@ public class OpenPgpMessageInputStreamTest {
         assertNull(metadata.getCompressionAlgorithm());
         assertFalse(metadata.getVerifiedInlineSignatures().isEmpty());
         assertTrue(metadata.getRejectedInlineSignatures().isEmpty());
+    }
+
+    @Test
+    public void readAfterCloseTest() throws PGPException, IOException {
+        OpenPgpMessageInputStream pgpIn = get(SENC_LIT, ConsumerOptions.get()
+                .addDecryptionPassphrase(Passphrase.fromPassword(PASSPHRASE)));
+        Streams.drain(pgpIn); // read all
+
+        byte[] buf = new byte[1024];
+        assertEquals(-1, pgpIn.read(buf));
+        assertEquals(-1, pgpIn.read());
+        assertEquals(-1, pgpIn.read(buf));
+        assertEquals(-1, pgpIn.read());
+
+        pgpIn.close();
+        pgpIn.getMetadata();
     }
 
     private static Tuple<String, MessageMetadata> processReadBuffered(String armoredMessage, ConsumerOptions options)


### PR DESCRIPTION
…nPgpMessageException when calling read() on drained stream