### PR TITLE
Bump checkstyle plugin version to 10.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ allprojects {
 
     // checkstyle
     checkstyle {
-        toolVersion = '8.45.1'
+        toolVersion = '10.12.1'
     }
 
     group 'org.pgpainless'


### PR DESCRIPTION
Bumps checkstyles transitive dependency on vulnerable guava from 30.1.1 to 31.1

Fixes https://github.com/pgpainless/pgpainless/security/dependabot/6
Fixes https://github.com/pgpainless/pgpainless/security/dependabot/5
Fixes https://github.com/pgpainless/pgpainless/security/dependabot/4

See #387 