### PR TITLE
Add support for PreferredAEADCiphersuites subpacket

### DIFF
--- a/pgpainless-core/src/main/java/org/pgpainless/algorithm/AEADAlgorithmCombination.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/algorithm/AEADAlgorithmCombination.java
@@ -26,7 +26,14 @@ public final class AEADAlgorithmCombination {
     private AEADAlgorithmCombination(@Nonnull SymmetricKeyAlgorithm symmetricKeyAlgorithm,
                                     @Nonnull AEADAlgorithm aeadAlgorithm) {
         this.aeadAlgorithm = aeadAlgorithm;
-        this.symmetricKeyAlgorithm = symmetricKeyAlgorithm;
+        this.symmetricKeyAlgorithm = requireNotUnencrypted(symmetricKeyAlgorithm);
+    }
+
+    private static SymmetricKeyAlgorithm requireNotUnencrypted(SymmetricKeyAlgorithm algorithm) {
+        if (algorithm == SymmetricKeyAlgorithm.NULL) {
+            throw new IllegalArgumentException("Symmetric Key Algorithm MUST NOT be NULL (unencrypted).");
+        }
+        return algorithm;
     }
 
     @Nonnull

--- a/pgpainless-core/src/main/java/org/pgpainless/algorithm/AEADAlgorithmCombination.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/algorithm/AEADAlgorithmCombination.java
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2023 Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.pgpainless.algorithm;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.bouncycastle.bcpg.sig.PreferredAEADCiphersuites;
+
+public final class AEADAlgorithmCombination {
+
+    private final AEADAlgorithm aeadAlgorithm;
+    private final SymmetricKeyAlgorithm symmetricKeyAlgorithm;
+
+    /**
+     * AES-128 + OCB is a MUST implement and is therefore implicitly supported.
+     *
+     * @see <a href="https://openpgp-wg.gitlab.io/rfc4880bis/#name-preferred-aead-ciphersuites">
+     * Crypto-Refresh § 5.2.3.15. Preferred AEAD Ciphersuites</a>
+     */
+    public static AEADAlgorithmCombination AES_128_OCB = AEADAlgorithmCombination.from(
+            SymmetricKeyAlgorithm.AES_128, AEADAlgorithm.OCB);
+
+    private AEADAlgorithmCombination(@Nonnull SymmetricKeyAlgorithm symmetricKeyAlgorithm,
+                                    @Nonnull AEADAlgorithm aeadAlgorithm) {
+        this.aeadAlgorithm = aeadAlgorithm;
+        this.symmetricKeyAlgorithm = symmetricKeyAlgorithm;
+    }
+
+    @Nonnull
+    public AEADAlgorithm getAeadAlgorithm() {
+        return aeadAlgorithm;
+    }
+
+    @Nonnull
+    public SymmetricKeyAlgorithm getSymmetricKeyAlgorithm() {
+        return symmetricKeyAlgorithm;
+    }
+
+    public static AEADAlgorithmCombination from(@Nonnull SymmetricKeyAlgorithm symmetricKeyAlgorithm,
+                                                @Nonnull AEADAlgorithm aeadAlgorithm) {
+        return new AEADAlgorithmCombination(symmetricKeyAlgorithm, aeadAlgorithm);
+    }
+
+    @Nullable
+    public static AEADAlgorithmCombination from(PreferredAEADCiphersuites.Combination combination) {
+        return fromIds(combination.getSymmetricAlgorithm(), combination.getAeadAlgorithm());
+    }
+
+    @Nonnull
+    public static AEADAlgorithmCombination requireFrom(PreferredAEADCiphersuites.Combination combination) {
+        return requireFromIds(combination.getSymmetricAlgorithm(), combination.getAeadAlgorithm());
+    }
+
+    @Nullable
+    public static AEADAlgorithmCombination fromIds(int symmetricAlgorithmId, int aeadAlgorithmId) {
+        SymmetricKeyAlgorithm symmetric = SymmetricKeyAlgorithm.fromId(symmetricAlgorithmId);
+        AEADAlgorithm aead = AEADAlgorithm.fromId(aeadAlgorithmId);
+
+        if (symmetric == null || aead == null) {
+            return null;
+        }
+
+        return new AEADAlgorithmCombination(symmetric, aead);
+    }
+
+    @Nonnull
+    public static AEADAlgorithmCombination requireFromIds(int symmetricAlgorithmId, int aeadAlgorithmId) {
+        return from(SymmetricKeyAlgorithm.requireFromId(symmetricAlgorithmId), AEADAlgorithm.requireFromId(aeadAlgorithmId));
+    }
+}

--- a/pgpainless-core/src/main/java/org/pgpainless/algorithm/AlgorithmSuite.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/algorithm/AlgorithmSuite.java
@@ -4,6 +4,7 @@
 
 package org.pgpainless.algorithm;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
@@ -16,33 +17,71 @@ import java.util.Set;
  */
 public class AlgorithmSuite {
 
+    private static final List<SymmetricKeyAlgorithm> defaultSymmetricAlgorithms = Arrays.asList(
+            SymmetricKeyAlgorithm.AES_256,
+            SymmetricKeyAlgorithm.AES_192,
+            SymmetricKeyAlgorithm.AES_128);
+    private static final List<HashAlgorithm> defaultHashAlgorithms = Arrays.asList(
+            HashAlgorithm.SHA512,
+            HashAlgorithm.SHA384,
+            HashAlgorithm.SHA256,
+            HashAlgorithm.SHA224);
+    private static final List<CompressionAlgorithm> defaultCompressionAlgorithms = Arrays.asList(
+            CompressionAlgorithm.ZLIB,
+            CompressionAlgorithm.BZIP2,
+            CompressionAlgorithm.ZIP,
+            CompressionAlgorithm.UNCOMPRESSED);
+    private static final List<AEADAlgorithmCombination> defaultAEADAlgorithms = Arrays.asList(
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_256, AEADAlgorithm.OCB),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_256, AEADAlgorithm.EAX),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_256, AEADAlgorithm.GCM),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_192, AEADAlgorithm.OCB),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_192, AEADAlgorithm.EAX),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_192, AEADAlgorithm.GCM),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_128, AEADAlgorithm.OCB),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_128, AEADAlgorithm.EAX),
+            AEADAlgorithmCombination.from(SymmetricKeyAlgorithm.AES_128, AEADAlgorithm.GCM));
     private static final AlgorithmSuite defaultAlgorithmSuite = new AlgorithmSuite(
-            Arrays.asList(
-                    SymmetricKeyAlgorithm.AES_256,
-                    SymmetricKeyAlgorithm.AES_192,
-                    SymmetricKeyAlgorithm.AES_128),
-            Arrays.asList(
-                    HashAlgorithm.SHA512,
-                    HashAlgorithm.SHA384,
-                    HashAlgorithm.SHA256,
-                    HashAlgorithm.SHA224),
-            Arrays.asList(
-                    CompressionAlgorithm.ZLIB,
-                    CompressionAlgorithm.BZIP2,
-                    CompressionAlgorithm.ZIP,
-                    CompressionAlgorithm.UNCOMPRESSED)
-    );
+            defaultSymmetricAlgorithms,
+            defaultHashAlgorithms,
+            defaultCompressionAlgorithms,
+            defaultAEADAlgorithms);
 
     private final Set<SymmetricKeyAlgorithm> symmetricKeyAlgorithms;
     private final Set<HashAlgorithm> hashAlgorithms;
     private final Set<CompressionAlgorithm> compressionAlgorithms;
+    private final Set<AEADAlgorithmCombination> aeadAlgorithms;
 
-    public AlgorithmSuite(List<SymmetricKeyAlgorithm> symmetricKeyAlgorithms,
-                          List<HashAlgorithm> hashAlgorithms,
-                          List<CompressionAlgorithm> compressionAlgorithms) {
+    /**
+     * Create a new AlgorithmSuite.
+     *
+     * @deprecated use {@link AlgorithmSuite#AlgorithmSuite(List, List, List, List)} instead.
+     * @param symmetricKeyAlgorithms preferred symmetric algorithms
+     * @param hashAlgorithms preferred hash algorithms
+     * @param compressionAlgorithms preferred compression algorithms
+     */
+    @Deprecated
+    public AlgorithmSuite(@Nonnull List<SymmetricKeyAlgorithm> symmetricKeyAlgorithms,
+                          @Nonnull List<HashAlgorithm> hashAlgorithms,
+                          @Nonnull List<CompressionAlgorithm> compressionAlgorithms) {
+        this(symmetricKeyAlgorithms, hashAlgorithms, compressionAlgorithms, defaultAEADAlgorithms);
+    }
+
+    /**
+     * Create a new AlgorithmSuite.
+     * @param symmetricKeyAlgorithms preferred symmetric algorithms
+     * @param hashAlgorithms preferred hash algorithms
+     * @param compressionAlgorithms preferred compression algorithms
+     * @param aeadAlgorithms preferred AEAD algorithm combinations
+     */
+    public AlgorithmSuite(@Nonnull List<SymmetricKeyAlgorithm> symmetricKeyAlgorithms,
+                          @Nonnull List<HashAlgorithm> hashAlgorithms,
+                          @Nonnull List<CompressionAlgorithm> compressionAlgorithms,
+                          @Nonnull List<AEADAlgorithmCombination> aeadAlgorithms) {
         this.symmetricKeyAlgorithms = Collections.unmodifiableSet(new LinkedHashSet<>(symmetricKeyAlgorithms));
         this.hashAlgorithms = Collections.unmodifiableSet(new LinkedHashSet<>(hashAlgorithms));
         this.compressionAlgorithms = Collections.unmodifiableSet(new LinkedHashSet<>(compressionAlgorithms));
+        this.aeadAlgorithms = Collections.unmodifiableSet(new LinkedHashSet<>(aeadAlgorithms));
     }
 
     public Set<SymmetricKeyAlgorithm> getSymmetricKeyAlgorithms() {
@@ -57,7 +96,12 @@ public class AlgorithmSuite {
         return new LinkedHashSet<>(compressionAlgorithms);
     }
 
+    public Set<AEADAlgorithmCombination> getAEADAlgorithms() {
+        return new LinkedHashSet<>(aeadAlgorithms);
+    }
+
     public static AlgorithmSuite getDefaultAlgorithmSuite() {
         return defaultAlgorithmSuite;
     }
+
 }

--- a/pgpainless-core/src/main/java/org/pgpainless/key/generation/KeySpecBuilder.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/generation/KeySpecBuilder.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 
 import org.pgpainless.PGPainless;
+import org.pgpainless.algorithm.AEADAlgorithmCombination;
 import org.pgpainless.algorithm.AlgorithmSuite;
 import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.Feature;
@@ -32,6 +33,7 @@ public class KeySpecBuilder implements KeySpecBuilderInterface {
     private Set<CompressionAlgorithm> preferredCompressionAlgorithms = algorithmSuite.getCompressionAlgorithms();
     private Set<HashAlgorithm> preferredHashAlgorithms = algorithmSuite.getHashAlgorithms();
     private Set<SymmetricKeyAlgorithm> preferredSymmetricAlgorithms = algorithmSuite.getSymmetricKeyAlgorithms();
+    private Set<AEADAlgorithmCombination> preferredAEADAlgorithms = algorithmSuite.getAEADAlgorithms();
     private Date keyCreationDate;
 
     KeySpecBuilder(@Nonnull KeyType type, KeyFlag flag, KeyFlag... flags) {
@@ -74,6 +76,13 @@ public class KeySpecBuilder implements KeySpecBuilderInterface {
     }
 
     @Override
+    public KeySpecBuilder overridePreferredAEADAlgorithms(
+            @Nonnull AEADAlgorithmCombination... preferredAEADAlgorithms) {
+        this.preferredAEADAlgorithms = new LinkedHashSet<>(Arrays.asList(preferredAEADAlgorithms));
+        return this;
+    }
+
+    @Override
     public KeySpecBuilder setKeyCreationDate(@Nonnull Date creationDate) {
         this.keyCreationDate = creationDate;
         return this;
@@ -85,6 +94,7 @@ public class KeySpecBuilder implements KeySpecBuilderInterface {
         this.hashedSubpackets.setPreferredCompressionAlgorithms(preferredCompressionAlgorithms);
         this.hashedSubpackets.setPreferredHashAlgorithms(preferredHashAlgorithms);
         this.hashedSubpackets.setPreferredSymmetricKeyAlgorithms(preferredSymmetricAlgorithms);
+        this.hashedSubpackets.setPreferredAEADCiphersuites(preferredAEADAlgorithms);
         this.hashedSubpackets.setFeatures(Feature.MODIFICATION_DETECTION);
 
         return new KeySpec(type, (SignatureSubpackets) hashedSubpackets, false, keyCreationDate);

--- a/pgpainless-core/src/main/java/org/pgpainless/key/generation/KeySpecBuilderInterface.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/key/generation/KeySpecBuilderInterface.java
@@ -6,6 +6,7 @@ package org.pgpainless.key.generation;
 
 import javax.annotation.Nonnull;
 
+import org.pgpainless.algorithm.AEADAlgorithmCombination;
 import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.HashAlgorithm;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
@@ -19,6 +20,8 @@ public interface KeySpecBuilderInterface {
     KeySpecBuilder overridePreferredHashAlgorithms(@Nonnull HashAlgorithm... preferredHashAlgorithms);
 
     KeySpecBuilder overridePreferredSymmetricKeyAlgorithms(@Nonnull SymmetricKeyAlgorithm... preferredSymmetricKeyAlgorithms);
+
+    KeySpecBuilder overridePreferredAEADAlgorithms(@Nonnull AEADAlgorithmCombination... preferredAEADAlgorithms);
 
     KeySpecBuilder setKeyCreationDate(@Nonnull Date creationDate);
 

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SelfSignatureSubpackets.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SelfSignatureSubpackets.java
@@ -13,15 +13,18 @@ import javax.annotation.Nullable;
 import org.bouncycastle.bcpg.sig.Features;
 import org.bouncycastle.bcpg.sig.KeyExpirationTime;
 import org.bouncycastle.bcpg.sig.KeyFlags;
+import org.bouncycastle.bcpg.sig.PreferredAEADCiphersuites;
 import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.RevocationKey;
 import org.bouncycastle.openpgp.PGPPublicKey;
+import org.pgpainless.algorithm.AEADAlgorithm;
 import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.Feature;
 import org.pgpainless.algorithm.HashAlgorithm;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
+import org.pgpainless.util.Tuple;
 
 public interface SelfSignatureSubpackets extends BaseSignatureSubpackets {
 
@@ -56,6 +59,14 @@ public interface SelfSignatureSubpackets extends BaseSignatureSubpackets {
 
     SelfSignatureSubpackets setKeyExpirationTime(@Nullable KeyExpirationTime keyExpirationTime);
 
+    SelfSignatureSubpackets setPreferredAEADCiphersuites(Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>... algorithms);
+
+    SelfSignatureSubpackets setPreferredAEADCiphersuites(Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms);
+
+    SelfSignatureSubpackets setPreferredAEADCiphersuites(boolean isCritical, Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms);
+
+    SelfSignatureSubpackets setPreferredAEADCiphersuites(@Nullable PreferredAEADCiphersuites algorithms);
+
     SelfSignatureSubpackets setPreferredCompressionAlgorithms(CompressionAlgorithm... algorithms);
 
     SelfSignatureSubpackets setPreferredCompressionAlgorithms(Set<CompressionAlgorithm> algorithms);
@@ -64,14 +75,6 @@ public interface SelfSignatureSubpackets extends BaseSignatureSubpackets {
 
     SelfSignatureSubpackets setPreferredCompressionAlgorithms(@Nullable PreferredAlgorithms algorithms);
 
-    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(SymmetricKeyAlgorithm... algorithms);
-
-    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(Set<SymmetricKeyAlgorithm> algorithms);
-
-    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(boolean isCritical, Set<SymmetricKeyAlgorithm> algorithms);
-
-    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(@Nullable PreferredAlgorithms algorithms);
-
     SelfSignatureSubpackets setPreferredHashAlgorithms(HashAlgorithm... algorithms);
 
     SelfSignatureSubpackets setPreferredHashAlgorithms(Set<HashAlgorithm> algorithms);
@@ -79,6 +82,14 @@ public interface SelfSignatureSubpackets extends BaseSignatureSubpackets {
     SelfSignatureSubpackets setPreferredHashAlgorithms(boolean isCritical, Set<HashAlgorithm> algorithms);
 
     SelfSignatureSubpackets setPreferredHashAlgorithms(@Nullable PreferredAlgorithms algorithms);
+
+    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(SymmetricKeyAlgorithm... algorithms);
+
+    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(Set<SymmetricKeyAlgorithm> algorithms);
+
+    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(boolean isCritical, Set<SymmetricKeyAlgorithm> algorithms);
+
+    SelfSignatureSubpackets setPreferredSymmetricKeyAlgorithms(@Nullable PreferredAlgorithms algorithms);
 
     SelfSignatureSubpackets addRevocationKey(@Nonnull PGPPublicKey revocationKey);
 

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SelfSignatureSubpackets.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SelfSignatureSubpackets.java
@@ -18,13 +18,12 @@ import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.RevocationKey;
 import org.bouncycastle.openpgp.PGPPublicKey;
-import org.pgpainless.algorithm.AEADAlgorithm;
+import org.pgpainless.algorithm.AEADAlgorithmCombination;
 import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.Feature;
 import org.pgpainless.algorithm.HashAlgorithm;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
-import org.pgpainless.util.Tuple;
 
 public interface SelfSignatureSubpackets extends BaseSignatureSubpackets {
 
@@ -59,11 +58,11 @@ public interface SelfSignatureSubpackets extends BaseSignatureSubpackets {
 
     SelfSignatureSubpackets setKeyExpirationTime(@Nullable KeyExpirationTime keyExpirationTime);
 
-    SelfSignatureSubpackets setPreferredAEADCiphersuites(Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>... algorithms);
+    SelfSignatureSubpackets setPreferredAEADCiphersuites(AEADAlgorithmCombination... algorithms);
 
-    SelfSignatureSubpackets setPreferredAEADCiphersuites(Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms);
+    SelfSignatureSubpackets setPreferredAEADCiphersuites(Set<AEADAlgorithmCombination> algorithms);
 
-    SelfSignatureSubpackets setPreferredAEADCiphersuites(boolean isCritical, Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms);
+    SelfSignatureSubpackets setPreferredAEADCiphersuites(boolean isCritical, Set<AEADAlgorithmCombination> algorithms);
 
     SelfSignatureSubpackets setPreferredAEADCiphersuites(@Nullable PreferredAEADCiphersuites algorithms);
 

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpackets.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpackets.java
@@ -43,7 +43,7 @@ import org.bouncycastle.bcpg.sig.TrustSignature;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSignature;
 import org.bouncycastle.openpgp.PGPSignatureSubpacketVector;
-import org.pgpainless.algorithm.AEADAlgorithm;
+import org.pgpainless.algorithm.AEADAlgorithmCombination;
 import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.Feature;
 import org.pgpainless.algorithm.HashAlgorithm;
@@ -51,7 +51,6 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.PublicKeyAlgorithm;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
 import org.pgpainless.key.util.RevocationAttributes;
-import org.pgpainless.util.Tuple;
 
 public class SignatureSubpackets
         implements BaseSignatureSubpackets, SelfSignatureSubpackets, CertificationSubpackets, RevocationSignatureSubpackets {
@@ -318,23 +317,24 @@ public class SignatureSubpackets
     }
 
     @Override
-    public SelfSignatureSubpackets setPreferredAEADCiphersuites(Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>... algorithms) {
+    public SelfSignatureSubpackets setPreferredAEADCiphersuites(AEADAlgorithmCombination... algorithms) {
         return setPreferredAEADCiphersuites(new LinkedHashSet<>(Arrays.asList(algorithms)));
     }
 
     @Override
-    public SelfSignatureSubpackets setPreferredAEADCiphersuites(Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms) {
+    public SelfSignatureSubpackets setPreferredAEADCiphersuites(Set<AEADAlgorithmCombination> algorithms) {
         return setPreferredAEADCiphersuites(false, algorithms);
     }
 
     @Override
-    public SelfSignatureSubpackets setPreferredAEADCiphersuites(boolean isCritical, Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms) {
+    public SelfSignatureSubpackets setPreferredAEADCiphersuites(boolean isCritical, Set<AEADAlgorithmCombination> algorithms) {
         List<PreferredAEADCiphersuites.Combination> combinations = new ArrayList<>();
-        Iterator<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> iterator = algorithms.iterator();
+        Iterator<AEADAlgorithmCombination> iterator = algorithms.iterator();
         while (iterator.hasNext()) {
-            Tuple<SymmetricKeyAlgorithm, AEADAlgorithm> tuple = iterator.next();
+            AEADAlgorithmCombination combination = iterator.next();
             combinations.add(new PreferredAEADCiphersuites.Combination(
-                    tuple.getA().getAlgorithmId(), tuple.getB().getAlgorithmId()));
+                    combination.getSymmetricKeyAlgorithm().getAlgorithmId(),
+                    combination.getAeadAlgorithm().getAlgorithmId()));
         }
         PreferredAEADCiphersuites subpacket = new PreferredAEADCiphersuites(
                 isCritical, combinations.toArray(new PreferredAEADCiphersuites.Combination[0]));

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpackets.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpackets.java
@@ -28,6 +28,7 @@ import org.bouncycastle.bcpg.sig.KeyExpirationTime;
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.NotationData;
 import org.bouncycastle.bcpg.sig.PolicyURI;
+import org.bouncycastle.bcpg.sig.PreferredAEADCiphersuites;
 import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.RegularExpression;
@@ -42,6 +43,7 @@ import org.bouncycastle.bcpg.sig.TrustSignature;
 import org.bouncycastle.openpgp.PGPPublicKey;
 import org.bouncycastle.openpgp.PGPSignature;
 import org.bouncycastle.openpgp.PGPSignatureSubpacketVector;
+import org.pgpainless.algorithm.AEADAlgorithm;
 import org.pgpainless.algorithm.CompressionAlgorithm;
 import org.pgpainless.algorithm.Feature;
 import org.pgpainless.algorithm.HashAlgorithm;
@@ -49,6 +51,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.PublicKeyAlgorithm;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
 import org.pgpainless.key.util.RevocationAttributes;
+import org.pgpainless.util.Tuple;
 
 public class SignatureSubpackets
         implements BaseSignatureSubpackets, SelfSignatureSubpackets, CertificationSubpackets, RevocationSignatureSubpackets {
@@ -68,6 +71,7 @@ public class SignatureSubpackets
     private PreferredAlgorithms preferredCompressionAlgorithms;
     private PreferredAlgorithms preferredSymmetricKeyAlgorithms;
     private PreferredAlgorithms preferredHashAlgorithms;
+    private PreferredAEADCiphersuites preferredAEADCiphersuites;
     private final List<EmbeddedSignature> embeddedSignatureList = new ArrayList<>();
     private SignerUserID signerUserId;
     private KeyExpirationTime keyExpirationTime;
@@ -311,6 +315,40 @@ public class SignatureSubpackets
     public SignatureSubpackets setKeyExpirationTime(@Nullable KeyExpirationTime keyExpirationTime) {
         this.keyExpirationTime = keyExpirationTime;
         return this;
+    }
+
+    @Override
+    public SelfSignatureSubpackets setPreferredAEADCiphersuites(Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>... algorithms) {
+        return setPreferredAEADCiphersuites(new LinkedHashSet<>(Arrays.asList(algorithms)));
+    }
+
+    @Override
+    public SelfSignatureSubpackets setPreferredAEADCiphersuites(Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms) {
+        return setPreferredAEADCiphersuites(false, algorithms);
+    }
+
+    @Override
+    public SelfSignatureSubpackets setPreferredAEADCiphersuites(boolean isCritical, Set<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> algorithms) {
+        List<PreferredAEADCiphersuites.Combination> combinations = new ArrayList<>();
+        Iterator<Tuple<SymmetricKeyAlgorithm, AEADAlgorithm>> iterator = algorithms.iterator();
+        while (iterator.hasNext()) {
+            Tuple<SymmetricKeyAlgorithm, AEADAlgorithm> tuple = iterator.next();
+            combinations.add(new PreferredAEADCiphersuites.Combination(
+                    tuple.getA().getAlgorithmId(), tuple.getB().getAlgorithmId()));
+        }
+        PreferredAEADCiphersuites subpacket = new PreferredAEADCiphersuites(
+                isCritical, combinations.toArray(new PreferredAEADCiphersuites.Combination[0]));
+        return setPreferredAEADCiphersuites(subpacket);
+    }
+
+    @Override
+    public SelfSignatureSubpackets setPreferredAEADCiphersuites(@Nullable PreferredAEADCiphersuites algorithms) {
+        this.preferredAEADCiphersuites = algorithms;
+        return this;
+    }
+
+    public PreferredAEADCiphersuites getPreferredAEADCiphersuites() {
+        return preferredAEADCiphersuites;
     }
 
     public KeyExpirationTime getKeyExpirationTimeSubpacket() {

--- a/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpacketsHelper.java
+++ b/pgpainless-core/src/main/java/org/pgpainless/signature/subpackets/SignatureSubpacketsHelper.java
@@ -13,6 +13,7 @@ import org.bouncycastle.bcpg.sig.KeyExpirationTime;
 import org.bouncycastle.bcpg.sig.KeyFlags;
 import org.bouncycastle.bcpg.sig.NotationData;
 import org.bouncycastle.bcpg.sig.PolicyURI;
+import org.bouncycastle.bcpg.sig.PreferredAEADCiphersuites;
 import org.bouncycastle.bcpg.sig.PreferredAlgorithms;
 import org.bouncycastle.bcpg.sig.PrimaryUserID;
 import org.bouncycastle.bcpg.sig.RegularExpression;
@@ -79,6 +80,9 @@ public class SignatureSubpacketsHelper {
                 case preferredCompressionAlgorithms:
                     subpackets.setPreferredCompressionAlgorithms((PreferredAlgorithms) subpacket);
                     break;
+                case preferredAEADAlgorithms:
+                    subpackets.setPreferredAEADCiphersuites((PreferredAEADCiphersuites) subpacket);
+                    break;
                 case primaryUserId:
                     PrimaryUserID primaryUserID = (PrimaryUserID) subpacket;
                     subpackets.setPrimaryUserId(primaryUserID);
@@ -128,7 +132,6 @@ public class SignatureSubpacketsHelper {
                 case keyServerPreferences:
                 case preferredKeyServers:
                 case placeholder:
-                case preferredAEADAlgorithms:
                 case attestedCertification:
                     subpackets.addResidualSubpacket(subpacket);
                     break;
@@ -161,6 +164,7 @@ public class SignatureSubpacketsHelper {
         addSubpacket(generator, subpackets.getPreferredCompressionAlgorithmsSubpacket());
         addSubpacket(generator, subpackets.getPreferredSymmetricKeyAlgorithmsSubpacket());
         addSubpacket(generator, subpackets.getPreferredHashAlgorithmsSubpacket());
+        addSubpacket(generator, subpackets.getPreferredAEADCiphersuites());
         for (EmbeddedSignature embeddedSignature : subpackets.getEmbeddedSignatureSubpackets()) {
             addSubpacket(generator, embeddedSignature);
         }


### PR DESCRIPTION
Requires BC 1.77
See https://github.com/bcgit/bc-java/pull/1464