### PR TITLE
build: add ktfmt via Spotless

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
 
 plugins {
     id 'org.jetbrains.kotlin.jvm' version "1.8.10"
+    id 'com.diffplug.spotless' version '6.22.0' apply false
 }
 
 apply from: 'version.gradle'
@@ -30,6 +31,7 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'checkstyle'
     apply plugin: 'kotlin'
+    apply plugin: 'com.diffplug.spotless'
 
     compileJava {
         options.release = 8
@@ -45,6 +47,12 @@ allprojects {
     // checkstyle
     checkstyle {
         toolVersion = '10.12.1'
+    }
+
+    spotless {
+      kotlin {
+        ktfmt().dropboxStyle()
+      }
     }
 
     group 'org.pgpainless'


### PR DESCRIPTION
Fixes #408

ktfmt uses 'Google style' by default with 2 space indents, if you want it to be 4 spaces instead I can enable the 'Dropbox style' and redo the PR.

Alternatively since the pgpainless2 branch is not being actively deployed (AFAIK), it might be "better" to avoid this massive reformat commit and for me to rebuild your Kotlin conversion commits with the formatting applied at each step which you can then force push into the `pgpainless2` branch, but I understand that the security implications of that might be untenable for the project.