### PR TITLE
add unit test to read decryption stream beyond end

### DIFF
--- a/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/DecryptAndVerifyMessageTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/decryption_verification/DecryptAndVerifyMessageTest.java
@@ -84,6 +84,24 @@ public class DecryptAndVerifyMessageTest {
 
     @TestTemplate
     @ExtendWith(TestAllImplementations.class)
+    public void decryptMessageAndReadBeyondEndTest() throws Exception {
+        final String encryptedMessage = TestKeys.MSG_SIGN_CRYPT_JULIET_JULIET;
+
+        final ConsumerOptions options = new ConsumerOptions()
+                .addDecryptionKey(juliet)
+                .addVerificationCert(KeyRingUtils.publicKeyRingFrom(juliet));
+
+        try (final DecryptionStream decryptor = PGPainless.decryptAndOrVerify()
+                .onInputStream(new ByteArrayInputStream(encryptedMessage.getBytes()))
+                .withOptions(options);
+             final ByteArrayOutputStream toPlain = new ByteArrayOutputStream()) {
+            Streams.pipeAll(decryptor, toPlain);
+            assertEquals(-1, decryptor.read());
+        }
+    }
+
+    @TestTemplate
+    @ExtendWith(TestAllImplementations.class)
     public void decryptMessageAndVerifySignatureByteByByteTest() throws Exception {
         String encryptedMessage = TestKeys.MSG_SIGN_CRYPT_JULIET_JULIET;
 


### PR DESCRIPTION
I currently don’t remember what the original crash was that led me to write this unit test. I just found that as uncommitted code. I think it had something to do with decrypting emails with attachments on Ltt.rs; but I don’t have a real world example for this currently other than this artificial unit test.