### PR TITLE
Rename EDDSA to EDDSA_LEGACY, XDH to XDH_LEGACY

### DIFF
--- a/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripEncryptDecryptCmdTest.java
+++ b/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripEncryptDecryptCmdTest.java
@@ -24,7 +24,7 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.slf4j.LoggerFactory;
 import sop.exception.SOPGPException;
@@ -304,7 +304,7 @@ public class RoundTripEncryptDecryptCmdTest extends CLITest {
             InvalidAlgorithmParameterException, NoSuchAlgorithmException, IOException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .addUserId("No Crypt <no@crypt.key>")
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519),
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
                 .build();
         PGPPublicKeyRing cert = PGPainless.extractCertificate(secretKeys);
@@ -323,7 +323,7 @@ public class RoundTripEncryptDecryptCmdTest extends CLITest {
             throws IOException, PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .addUserId("Cannot Sign <cannot@sign.key>")
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(
                         KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .build();

--- a/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripEncryptDecryptCmdTest.java
+++ b/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripEncryptDecryptCmdTest.java
@@ -25,7 +25,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.slf4j.LoggerFactory;
 import sop.exception.SOPGPException;
 
@@ -325,7 +325,7 @@ public class RoundTripEncryptDecryptCmdTest extends CLITest {
                 .addUserId("Cannot Sign <cannot@sign.key>")
                 .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(
-                        KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
+                        KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .build();
         File keyFile = writeFile("key.pgp", secretKeys.getEncoded());
         File certFile = writeFile("cert.pgp", PGPainless.extractCertificate(secretKeys).getEncoded());

--- a/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripSignVerifyCmdTest.java
+++ b/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripSignVerifyCmdTest.java
@@ -25,7 +25,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.slf4j.LoggerFactory;
@@ -202,7 +202,7 @@ public class RoundTripSignVerifyCmdTest extends CLITest {
             throws IOException, PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .addUserId("Cannot Sign <cannot@sign.key>")
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .build();
         File keyFile = writeFile("key.pgp", secretKeys.getEncoded());

--- a/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripSignVerifyCmdTest.java
+++ b/pgpainless-cli/src/test/java/org/pgpainless/cli/commands/RoundTripSignVerifyCmdTest.java
@@ -26,7 +26,7 @@ import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.slf4j.LoggerFactory;
 import sop.exception.SOPGPException;
@@ -203,7 +203,7 @@ public class RoundTripSignVerifyCmdTest extends CLITest {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .addUserId("Cannot Sign <cannot@sign.key>")
                 .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .build();
         File keyFile = writeFile("key.pgp", secretKeys.getEncoded());
 

--- a/pgpainless-core/src/main/kotlin/org/bouncycastle/extensions/PGPPublicKeyExtensions.kt
+++ b/pgpainless-core/src/main/kotlin/org/bouncycastle/extensions/PGPPublicKeyExtensions.kt
@@ -16,7 +16,7 @@ import org.pgpainless.key.generation.type.eddsa.EdDSACurve
 
 /**
  * For secret keys of types [PublicKeyAlgorithm.ECDSA], [PublicKeyAlgorithm.ECDH] and
- * [PublicKeyAlgorithm.EDDSA], this method returns the name of the underlying elliptic curve.
+ * [PublicKeyAlgorithm.EDDSA_LEGACY], this method returns the name of the underlying elliptic curve.
  *
  * For other key types or unknown curves, this method throws an [IllegalArgumentException].
  *
@@ -28,7 +28,7 @@ fun PGPPublicKey.getCurveName(): String {
             when (it) {
                 PublicKeyAlgorithm.ECDSA -> publicKeyPacket.key as ECDSAPublicBCPGKey
                 PublicKeyAlgorithm.ECDH -> publicKeyPacket.key as ECDHPublicBCPGKey
-                PublicKeyAlgorithm.EDDSA -> publicKeyPacket.key as EdDSAPublicBCPGKey
+                PublicKeyAlgorithm.EDDSA_LEGACY -> publicKeyPacket.key as EdDSAPublicBCPGKey
                 else -> throw IllegalArgumentException("No an elliptic curve public key ($it).")
             }
         }

--- a/pgpainless-core/src/main/kotlin/org/bouncycastle/extensions/PGPPublicKeyExtensions.kt
+++ b/pgpainless-core/src/main/kotlin/org/bouncycastle/extensions/PGPPublicKeyExtensions.kt
@@ -12,7 +12,7 @@ import org.bouncycastle.jcajce.provider.asymmetric.util.ECUtil
 import org.bouncycastle.openpgp.PGPPublicKey
 import org.pgpainless.algorithm.PublicKeyAlgorithm
 import org.pgpainless.key.OpenPgpFingerprint
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve
 
 /**
  * For secret keys of types [PublicKeyAlgorithm.ECDSA], [PublicKeyAlgorithm.ECDH] and
@@ -33,7 +33,8 @@ fun PGPPublicKey.getCurveName(): String {
             }
         }
         .let {
-            if (it.curveOID == GNUObjectIdentifiers.Ed25519) return EdDSACurve._Ed25519.curveName
+            if (it.curveOID == GNUObjectIdentifiers.Ed25519)
+                return EdDSALegacyCurve._Ed25519.curveName
             else it.curveOID
         }
         .let { it to ECUtil.getCurveName(it) }

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/algorithm/PublicKeyAlgorithm.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/algorithm/PublicKeyAlgorithm.kt
@@ -60,7 +60,7 @@ enum class PublicKeyAlgorithm(
     DIFFIE_HELLMAN(21, false, true),
 
     /** Digital Signature Algorithm based on twisted Edwards Curves. */
-    EDDSA(22, true, false),
+    EDDSA_LEGACY(22, true, false),
     ;
 
     fun isSigningCapable(): Boolean = signingCapable

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/KeyRingTemplates.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/KeyRingTemplates.kt
@@ -9,7 +9,7 @@ import org.pgpainless.PGPainless.Companion.buildKeyRing
 import org.pgpainless.algorithm.KeyFlag
 import org.pgpainless.key.generation.KeySpec.Companion.getBuilder
 import org.pgpainless.key.generation.type.KeyType
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve
 import org.pgpainless.key.generation.type.rsa.RsaLength
 import org.pgpainless.key.generation.type.xdh.XDHSpec
 import org.pgpainless.util.Passphrase
@@ -131,7 +131,7 @@ class KeyRingTemplates {
             .apply {
                 setPrimaryKey(
                     getBuilder(
-                        KeyType.EDDSA(EdDSACurve._Ed25519),
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.CERTIFY_OTHER,
                         KeyFlag.SIGN_DATA))
                 addSubkey(
@@ -179,13 +179,16 @@ class KeyRingTemplates {
     ): PGPSecretKeyRing =
         buildKeyRing()
             .apply {
-                setPrimaryKey(getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                setPrimaryKey(
+                    getBuilder(
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 addSubkey(
                     getBuilder(
                         KeyType.XDH(XDHSpec._X25519),
                         KeyFlag.ENCRYPT_COMMS,
                         KeyFlag.ENCRYPT_STORAGE))
-                addSubkey(getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA))
+                addSubkey(
+                    getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 setPassphrase(passphrase)
                 if (userId != null) {
                     addUserId(userId)

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/KeyRingTemplates.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/KeyRingTemplates.kt
@@ -11,7 +11,7 @@ import org.pgpainless.key.generation.KeySpec.Companion.getBuilder
 import org.pgpainless.key.generation.type.KeyType
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve
 import org.pgpainless.key.generation.type.rsa.RsaLength
-import org.pgpainless.key.generation.type.xdh.XDHSpec
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec
 import org.pgpainless.util.Passphrase
 
 class KeyRingTemplates {
@@ -136,7 +136,7 @@ class KeyRingTemplates {
                         KeyFlag.SIGN_DATA))
                 addSubkey(
                     getBuilder(
-                        KeyType.XDH(XDHSpec._X25519),
+                        KeyType.XDH_LEGACY(XDHLegacySpec._X25519),
                         KeyFlag.ENCRYPT_STORAGE,
                         KeyFlag.ENCRYPT_COMMS))
                 setPassphrase(passphrase)
@@ -184,7 +184,7 @@ class KeyRingTemplates {
                         KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 addSubkey(
                     getBuilder(
-                        KeyType.XDH(XDHSpec._X25519),
+                        KeyType.XDH_LEGACY(XDHLegacySpec._X25519),
                         KeyFlag.ENCRYPT_COMMS,
                         KeyFlag.ENCRYPT_STORAGE))
                 addSubkey(

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/KeyType.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/KeyType.kt
@@ -13,8 +13,8 @@ import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacy
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve
 import org.pgpainless.key.generation.type.rsa.RSA
 import org.pgpainless.key.generation.type.rsa.RsaLength
-import org.pgpainless.key.generation.type.xdh.XDH
-import org.pgpainless.key.generation.type.xdh.XDHSpec
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacy
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec
 
 @Suppress("INAPPLICABLE_JVM_NAME") // https://youtrack.jetbrains.com/issue/KT-31420
 interface KeyType {
@@ -103,6 +103,6 @@ interface KeyType {
         @JvmStatic
         fun EDDSA_LEGACY(curve: EdDSALegacyCurve): EdDSALegacy = EdDSALegacy.fromCurve(curve)
 
-        @JvmStatic fun XDH(curve: XDHSpec): XDH = XDH.fromSpec(curve)
+        @JvmStatic fun XDH_LEGACY(curve: XDHLegacySpec): XDHLegacy = XDHLegacy.fromSpec(curve)
     }
 }

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/KeyType.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/KeyType.kt
@@ -9,8 +9,8 @@ import org.pgpainless.algorithm.PublicKeyAlgorithm
 import org.pgpainless.key.generation.type.ecc.EllipticCurve
 import org.pgpainless.key.generation.type.ecc.ecdh.ECDH
 import org.pgpainless.key.generation.type.ecc.ecdsa.ECDSA
-import org.pgpainless.key.generation.type.eddsa.EdDSA
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacy
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve
 import org.pgpainless.key.generation.type.rsa.RSA
 import org.pgpainless.key.generation.type.rsa.RsaLength
 import org.pgpainless.key.generation.type.xdh.XDH
@@ -100,7 +100,8 @@ interface KeyType {
 
         @JvmStatic fun ECDSA(curve: EllipticCurve): ECDSA = ECDSA.fromCurve(curve)
 
-        @JvmStatic fun EDDSA(curve: EdDSACurve): EdDSA = EdDSA.fromCurve(curve)
+        @JvmStatic
+        fun EDDSA_LEGACY(curve: EdDSALegacyCurve): EdDSALegacy = EdDSALegacy.fromCurve(curve)
 
         @JvmStatic fun XDH(curve: XDHSpec): XDH = XDH.fromSpec(curve)
     }

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/ecc/EllipticCurve.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/ecc/EllipticCurve.kt
@@ -7,7 +7,7 @@ package org.pgpainless.key.generation.type.ecc
 /**
  * Elliptic curves for use with [org.pgpainless.key.generation.type.ecc.ecdh.ECDH] and
  * [org.pgpainless.key.generation.type.ecc.ecdsa.ECDSA]. For curve25519 related curve definitions
- * see [XDHSpec] and [org.pgpainless.key.generation.type.eddsa.EdDSACurve].
+ * see [XDHSpec] and [org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve].
  */
 enum class EllipticCurve(val curveName: String, val bitStrength: Int) {
     _P256("prime256v1", 256), // prime256v1 is equivalent to P-256, see

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/eddsa/EdDSA.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/eddsa/EdDSA.kt
@@ -10,7 +10,7 @@ import org.pgpainless.key.generation.type.KeyType
 
 class EdDSA private constructor(val curve: EdDSACurve) : KeyType {
     override val name = "EdDSA"
-    override val algorithm = PublicKeyAlgorithm.EDDSA
+    override val algorithm = PublicKeyAlgorithm.EDDSA_LEGACY
     override val bitStrength = curve.bitStrength
     override val algorithmSpec = ECNamedCurveGenParameterSpec(curve.curveName)
 

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/eddsa_legacy/EdDSALegacy.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/eddsa_legacy/EdDSALegacy.kt
@@ -2,19 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package org.pgpainless.key.generation.type.eddsa
+package org.pgpainless.key.generation.type.eddsa_legacy
 
 import org.bouncycastle.jce.spec.ECNamedCurveGenParameterSpec
 import org.pgpainless.algorithm.PublicKeyAlgorithm
 import org.pgpainless.key.generation.type.KeyType
 
-class EdDSA private constructor(val curve: EdDSACurve) : KeyType {
+class EdDSALegacy private constructor(val curve: EdDSALegacyCurve) : KeyType {
     override val name = "EdDSA"
     override val algorithm = PublicKeyAlgorithm.EDDSA_LEGACY
     override val bitStrength = curve.bitStrength
     override val algorithmSpec = ECNamedCurveGenParameterSpec(curve.curveName)
 
     companion object {
-        @JvmStatic fun fromCurve(curve: EdDSACurve) = EdDSA(curve)
+        @JvmStatic fun fromCurve(curve: EdDSALegacyCurve) = EdDSALegacy(curve)
     }
 }

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/eddsa_legacy/EdDSALegacyCurve.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/eddsa_legacy/EdDSALegacyCurve.kt
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package org.pgpainless.key.generation.type.eddsa
+package org.pgpainless.key.generation.type.eddsa_legacy
 
-enum class EdDSACurve(val curveName: String, val bitStrength: Int) {
+enum class EdDSALegacyCurve(val curveName: String, val bitStrength: Int) {
     _Ed25519("ed25519", 256),
     ;
 

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/xdh_legacy/XDHLegacy.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/xdh_legacy/XDHLegacy.kt
@@ -2,19 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package org.pgpainless.key.generation.type.xdh
+package org.pgpainless.key.generation.type.xdh_legacy
 
 import org.bouncycastle.jce.spec.ECNamedCurveGenParameterSpec
 import org.pgpainless.algorithm.PublicKeyAlgorithm
 import org.pgpainless.key.generation.type.KeyType
 
-class XDH private constructor(spec: XDHSpec) : KeyType {
+class XDHLegacy private constructor(spec: XDHLegacySpec) : KeyType {
     override val name = "XDH"
     override val algorithm = PublicKeyAlgorithm.ECDH
     override val bitStrength = spec.bitStrength
     override val algorithmSpec = ECNamedCurveGenParameterSpec(spec.algorithmName)
 
     companion object {
-        @JvmStatic fun fromSpec(spec: XDHSpec) = XDH(spec)
+        @JvmStatic fun fromSpec(spec: XDHLegacySpec) = XDHLegacy(spec)
     }
 }

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/xdh_legacy/XDHLegacySpec.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/key/generation/type/xdh_legacy/XDHLegacySpec.kt
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package org.pgpainless.key.generation.type.xdh
+package org.pgpainless.key.generation.type.xdh_legacy
 
-enum class XDHSpec(val algorithmName: String, val curveName: String, val bitStrength: Int) {
+enum class XDHLegacySpec(val algorithmName: String, val curveName: String, val bitStrength: Int) {
     _X25519("X25519", "curve25519", 256),
     ;
 

--- a/pgpainless-core/src/main/kotlin/org/pgpainless/policy/Policy.kt
+++ b/pgpainless-core/src/main/kotlin/org/pgpainless/policy/Policy.kt
@@ -374,7 +374,7 @@ class Policy(
                         put(PublicKeyAlgorithm.ECDSA, 250)
                         // Note: EdDSA is not mentioned in the BSI document.
                         //  We assume that the requirements are similar to other EC algorithms.
-                        put(PublicKeyAlgorithm.EDDSA, 250)
+                        put(PublicKeyAlgorithm.EDDSA_LEGACY, 250)
                         // §7.2.1
                         put(PublicKeyAlgorithm.DIFFIE_HELLMAN, 2000)
                         // §7.2.2

--- a/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/EncryptionOptionsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/EncryptionOptionsTest.java
@@ -33,7 +33,7 @@ import org.pgpainless.exception.KeyException;
 import org.pgpainless.key.SubkeyIdentifier;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.util.KeyRingUtils;
 import org.pgpainless.util.Passphrase;
@@ -51,7 +51,7 @@ public class EncryptionOptionsTest {
     @BeforeAll
     public static void generateKey() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         secretKeys = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER)
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER)
                         .build())
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS)
                         .build())
@@ -138,7 +138,7 @@ public class EncryptionOptionsTest {
     public void testAddRecipient_KeyWithoutEncryptionKeyFails() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         EncryptionOptions options = new EncryptionOptions();
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
                 .addUserId("test@pgpainless.org")
                 .build();
         PGPPublicKeyRing publicKeys = KeyRingUtils.publicKeyRingFrom(secretKeys);

--- a/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/EncryptionOptionsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/EncryptionOptionsTest.java
@@ -34,7 +34,7 @@ import org.pgpainless.key.SubkeyIdentifier;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.util.KeyRingUtils;
 import org.pgpainless.util.Passphrase;
 
@@ -53,9 +53,9 @@ public class EncryptionOptionsTest {
         secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER)
                         .build())
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS)
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS)
                         .build())
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_STORAGE)
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_STORAGE)
                         .build())
                 .addUserId("test@pgpainless.org")
                 .build();

--- a/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/MultiSigningSubkeyTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/MultiSigningSubkeyTest.java
@@ -23,7 +23,7 @@ import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.util.MultiMap;
 
@@ -55,7 +55,7 @@ public class MultiSigningSubkeyTest {
                 .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(KeyType.RSA(RsaLength._3072), KeyFlag.SIGN_DATA))
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .addUserId("Alice <alice@pgpainless.org>")
                 .build();
         signingCert = PGPainless.extractCertificate(signingKey);

--- a/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/MultiSigningSubkeyTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/MultiSigningSubkeyTest.java
@@ -21,7 +21,7 @@ import org.pgpainless.decryption_verification.SignatureVerification;
 import org.pgpainless.key.SubkeyIdentifier;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
@@ -52,8 +52,8 @@ public class MultiSigningSubkeyTest {
     @BeforeAll
     public static void generateKey() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         signingKey = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
-                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
+                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(KeyType.RSA(RsaLength._3072), KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .addUserId("Alice <alice@pgpainless.org>")

--- a/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/SigningTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/encryption_signing/SigningTest.java
@@ -40,7 +40,7 @@ import org.pgpainless.key.SubkeyIdentifier;
 import org.pgpainless.key.TestKeys;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.util.KeyRingUtils;
@@ -187,7 +187,7 @@ public class SigningTest {
             throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IOException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(
-                        KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
                         .overridePreferredHashAlgorithms())
                 .addUserId("Alice")
                 .build();
@@ -217,7 +217,7 @@ public class SigningTest {
             throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IOException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(
-                        KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
+                        KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
                         .overridePreferredHashAlgorithms(HashAlgorithm.MD5))
                 .addUserId("Alice")
                 .build();
@@ -246,7 +246,7 @@ public class SigningTest {
     public void signingWithNonCapableKeyThrowsKeyCannotSignException()
             throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addUserId("Alice")
                 .build();
 
@@ -262,7 +262,7 @@ public class SigningTest {
     public void signWithInvalidUserIdThrowsKeyValidationError()
             throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519),
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
                 .addUserId("Alice")
                 .build();

--- a/pgpainless-core/src/test/java/org/pgpainless/example/GenerateKeys.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/example/GenerateKeys.java
@@ -27,7 +27,7 @@ import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.KeySpecBuilder;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.util.UserId;
@@ -180,7 +180,7 @@ public class GenerateKeys {
         Passphrase passphrase = Passphrase.fromPassword("1nters3x");
 
         PGPSecretKeyRing secretKey = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519),
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         // The primary key MUST carry the CERTIFY_OTHER flag, but CAN carry additional flags
                         KeyFlag.CERTIFY_OTHER))
                 // Add the first subkey (in this case encryption)

--- a/pgpainless-core/src/test/java/org/pgpainless/example/GenerateKeys.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/example/GenerateKeys.java
@@ -74,9 +74,9 @@ public class GenerateKeys {
         KeyRingInfo keyInfo = new KeyRingInfo(secretKey);
         assertEquals(3, keyInfo.getSecretKeys().size());
         assertEquals(userId, keyInfo.getPrimaryUserId());
-        assertEquals(PublicKeyAlgorithm.EDDSA.getAlgorithmId(),
+        assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY.getAlgorithmId(),
                 keyInfo.getPublicKey().getAlgorithm());
-        assertEquals(PublicKeyAlgorithm.EDDSA.getAlgorithmId(),
+        assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY.getAlgorithmId(),
                 keyInfo.getSigningSubkeys().get(0).getAlgorithm());
         assertEquals(PublicKeyAlgorithm.ECDH.getAlgorithmId(),
                 keyInfo.getEncryptionSubkeys(EncryptionPurpose.ANY).get(0).getAlgorithm());

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/BrainpoolKeyGenerationTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/BrainpoolKeyGenerationTest.java
@@ -26,7 +26,7 @@ import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.info.KeyInfo;
 import org.pgpainless.key.util.UserId;
 import org.pgpainless.util.Passphrase;
@@ -73,7 +73,7 @@ public class BrainpoolKeyGenerationTest {
                         KeyType.ECDSA(EllipticCurve._BRAINPOOLP384R1), KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(
-                        KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
+                        KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .addSubkey(KeySpec.getBuilder(
                         KeyType.RSA(RsaLength._3072), KeyFlag.SIGN_DATA))
                 .addUserId(UserId.nameAndEmail("Alice", "alice@pgpainless.org"))
@@ -104,7 +104,7 @@ public class BrainpoolKeyGenerationTest {
 
         PGPSecretKey xdhSub = iterator.next();
         KeyInfo xdhInfo = new KeyInfo(xdhSub);
-        assertEquals(XDHSpec._X25519.getCurveName(), xdhInfo.getCurveName());
+        assertEquals(XDHLegacySpec._X25519.getCurveName(), xdhInfo.getCurveName());
         assertEquals(256, xdhSub.getPublicKey().getBitStrength());
 
         PGPSecretKey rsaSub = iterator.next();

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/BrainpoolKeyGenerationTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/BrainpoolKeyGenerationTest.java
@@ -24,7 +24,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.PublicKeyAlgorithm;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.info.KeyInfo;
@@ -71,7 +71,7 @@ public class BrainpoolKeyGenerationTest {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(
                         KeyType.ECDSA(EllipticCurve._BRAINPOOLP384R1), KeyFlag.CERTIFY_OTHER))
-                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA))
+                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(
                         KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .addSubkey(KeySpec.getBuilder(
@@ -99,7 +99,7 @@ public class BrainpoolKeyGenerationTest {
 
         PGPSecretKey eddsaSub = iterator.next();
         KeyInfo eddsaInfo = new KeyInfo(eddsaSub);
-        assertEquals(EdDSACurve._Ed25519.getName(), eddsaInfo.getCurveName());
+        assertEquals(EdDSALegacyCurve._Ed25519.getName(), eddsaInfo.getCurveName());
         assertEquals(256, eddsaSub.getPublicKey().getBitStrength());
 
         PGPSecretKey xdhSub = iterator.next();

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/CertificationKeyMustBeAbleToCertifyTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/CertificationKeyMustBeAbleToCertifyTest.java
@@ -12,7 +12,7 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.util.TestAllImplementations;
 
 public class CertificationKeyMustBeAbleToCertifyTest {
@@ -29,7 +29,7 @@ public class CertificationKeyMustBeAbleToCertifyTest {
                 KeyType.ECDH(EllipticCurve._P256),
                 KeyType.ECDH(EllipticCurve._P384),
                 KeyType.ECDH(EllipticCurve._P521),
-                KeyType.XDH(XDHSpec._X25519)
+                KeyType.XDH_LEGACY(XDHLegacySpec._X25519)
         };
         for (KeyType type : typesIncapableOfCreatingVerifications) {
             assertThrows(IllegalArgumentException.class, () -> PGPainless

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateEllipticCurveKeyTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateEllipticCurveKeyTest.java
@@ -38,7 +38,7 @@ public class GenerateEllipticCurveKeyTest {
                 .addUserId(UserId.onlyEmail("alice@wonderland.lit").toString())
                 .build();
 
-        assertEquals(PublicKeyAlgorithm.EDDSA.getAlgorithmId(), keyRing.getPublicKey().getAlgorithm());
+        assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY.getAlgorithmId(), keyRing.getPublicKey().getAlgorithm());
         UnlockSecretKey.unlockSecretKey(keyRing.getSecretKey(), SecretKeyRingProtector.unprotectedKeys());
     }
 }

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateEllipticCurveKeyTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateEllipticCurveKeyTest.java
@@ -17,7 +17,7 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.PublicKeyAlgorithm;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.protection.UnlockSecretKey;
@@ -32,7 +32,7 @@ public class GenerateEllipticCurveKeyTest {
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, PGPException {
         PGPSecretKeyRing keyRing = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(
-                        KeyType.EDDSA(EdDSACurve._Ed25519),
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS))
                 .addUserId(UserId.onlyEmail("alice@wonderland.lit").toString())

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateEllipticCurveKeyTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateEllipticCurveKeyTest.java
@@ -18,7 +18,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.PublicKeyAlgorithm;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.protection.UnlockSecretKey;
 import org.pgpainless.key.util.UserId;
@@ -34,7 +34,7 @@ public class GenerateEllipticCurveKeyTest {
                 .setPrimaryKey(KeySpec.getBuilder(
                         KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA))
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS))
                 .addUserId(UserId.onlyEmail("alice@wonderland.lit").toString())
                 .build();
 

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithCustomCreationDateTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithCustomCreationDateTest.java
@@ -22,7 +22,7 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.util.DateUtil;
 
@@ -34,7 +34,7 @@ public class GenerateKeyWithCustomCreationDateTest {
         Date creationDate = DateUtil.parseUTCDate("2018-06-11 14:12:09 UTC");
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
                         .setKeyCreationDate(creationDate)) // primary key with custom creation time
                 .addUserId("Alice")
                 .build();

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithCustomCreationDateTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithCustomCreationDateTest.java
@@ -23,7 +23,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.util.DateUtil;
 
 public class GenerateKeyWithCustomCreationDateTest {
@@ -33,7 +33,7 @@ public class GenerateKeyWithCustomCreationDateTest {
             throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         Date creationDate = DateUtil.parseUTCDate("2018-06-11 14:12:09 UTC");
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
                         .setKeyCreationDate(creationDate)) // primary key with custom creation time
                 .addUserId("Alice")

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutPrimaryKeyFlagsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutPrimaryKeyFlagsTest.java
@@ -34,7 +34,7 @@ import org.pgpainless.encryption_signing.SigningOptions;
 import org.pgpainless.exception.KeyException;
 import org.pgpainless.key.TestKeys;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
@@ -43,8 +43,8 @@ public class GenerateKeyWithoutPrimaryKeyFlagsTest {
 
     @Test
     public void generateKeyWithoutCertifyKeyFlag_cannotCertifyThirdParties() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IOException {
-        PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing().setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519)))
-                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA))
+        PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing().setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519)))
+                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_STORAGE, KeyFlag.ENCRYPT_COMMS))
                 .addUserId("Alice")
                 .build();

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutPrimaryKeyFlagsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutPrimaryKeyFlagsTest.java
@@ -35,7 +35,7 @@ import org.pgpainless.exception.KeyException;
 import org.pgpainless.key.TestKeys;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 
@@ -45,7 +45,7 @@ public class GenerateKeyWithoutPrimaryKeyFlagsTest {
     public void generateKeyWithoutCertifyKeyFlag_cannotCertifyThirdParties() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IOException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing().setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519)))
                 .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_STORAGE, KeyFlag.ENCRYPT_COMMS))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_STORAGE, KeyFlag.ENCRYPT_COMMS))
                 .addUserId("Alice")
                 .build();
         PGPPublicKeyRing cert = PGPainless.extractCertificate(secretKeys);

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutUserIdTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutUserIdTest.java
@@ -23,7 +23,7 @@ import org.pgpainless.encryption_signing.ProducerOptions;
 import org.pgpainless.encryption_signing.SigningOptions;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.timeframe.TestTimeFrameProvider;
@@ -49,7 +49,7 @@ public class GenerateKeyWithoutUserIdTest {
         PGPSecretKeyRing secretKey = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER).setKeyCreationDate(now))
                 .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA).setKeyCreationDate(now))
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE).setKeyCreationDate(now))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE).setKeyCreationDate(now))
                 .setExpirationDate(expirationDate)
                 .build();
 

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutUserIdTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/GenerateKeyWithoutUserIdTest.java
@@ -22,7 +22,7 @@ import org.pgpainless.encryption_signing.EncryptionStream;
 import org.pgpainless.encryption_signing.ProducerOptions;
 import org.pgpainless.encryption_signing.SigningOptions;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
@@ -47,8 +47,8 @@ public class GenerateKeyWithoutUserIdTest {
         Date now = new Date();
         Date expirationDate = TestTimeFrameProvider.defaultExpirationForCreationDate(now);
         PGPSecretKeyRing secretKey = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER).setKeyCreationDate(now))
-                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA).setKeyCreationDate(now))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER).setKeyCreationDate(now))
+                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA).setKeyCreationDate(now))
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE).setKeyCreationDate(now))
                 .setExpirationDate(expirationDate)
                 .build();

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/IllegalKeyFlagsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/IllegalKeyFlagsTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.util.TestAllImplementations;
 
@@ -29,9 +29,9 @@ public class IllegalKeyFlagsTest {
                 KeyType.XDH(XDHSpec._X25519), KeyFlag.AUTHENTICATION));
 
         assertThrows(IllegalArgumentException.class, () -> KeySpec.getBuilder(
-                KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.ENCRYPT_COMMS));
+                KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.ENCRYPT_COMMS));
 
         assertThrows(IllegalArgumentException.class, () -> KeySpec.getBuilder(
-                KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.ENCRYPT_STORAGE));
+                KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.ENCRYPT_STORAGE));
     }
 }

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/IllegalKeyFlagsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/IllegalKeyFlagsTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.util.TestAllImplementations;
 
 public class IllegalKeyFlagsTest {
@@ -20,13 +20,13 @@ public class IllegalKeyFlagsTest {
     @ExtendWith(TestAllImplementations.class)
     public void testKeyCannotCarryFlagsTest() {
         assertThrows(IllegalArgumentException.class, () -> KeySpec.getBuilder(
-                KeyType.XDH(XDHSpec._X25519), KeyFlag.SIGN_DATA));
+                KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.SIGN_DATA));
 
         assertThrows(IllegalArgumentException.class, () -> KeySpec.getBuilder(
-                KeyType.XDH(XDHSpec._X25519), KeyFlag.CERTIFY_OTHER));
+                KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.CERTIFY_OTHER));
 
         assertThrows(IllegalArgumentException.class, () -> KeySpec.getBuilder(
-                KeyType.XDH(XDHSpec._X25519), KeyFlag.AUTHENTICATION));
+                KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.AUTHENTICATION));
 
         assertThrows(IllegalArgumentException.class, () -> KeySpec.getBuilder(
                 KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.ENCRYPT_COMMS));

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/KeyGenerationSubpacketsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/KeyGenerationSubpacketsTest.java
@@ -30,7 +30,7 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.HashAlgorithm;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
@@ -113,7 +113,7 @@ public class KeyGenerationSubpacketsTest {
         List<PGPPublicKey> keysBefore = info.getPublicKeys();
 
         secretKeys = PGPainless.modifyKeyRing(secretKeys)
-                .addSubKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA).build(),
+                .addSubKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA).build(),
                         Passphrase.emptyPassphrase(), SecretKeyRingProtector.unprotectedKeys())
                 .done();
 

--- a/pgpainless-core/src/test/java/org/pgpainless/key/generation/KeyGenerationSubpacketsTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/generation/KeyGenerationSubpacketsTest.java
@@ -31,7 +31,7 @@ import org.pgpainless.algorithm.HashAlgorithm;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.signature.subpackets.SelfSignatureSubpackets;
@@ -130,7 +130,7 @@ public class KeyGenerationSubpacketsTest {
         assertNotNull(bindingSig.getHashedSubPackets().getEmbeddedSignatures().get(0));
 
         secretKeys = PGPainless.modifyKeyRing(secretKeys)
-                .addSubKey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS).build(),
+                .addSubKey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS).build(),
                         Passphrase.emptyPassphrase(),
                         new SelfSignatureSubpackets.Callback() {
                             @Override

--- a/pgpainless-core/src/test/java/org/pgpainless/key/info/KeyRingInfoTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/info/KeyRingInfoTest.java
@@ -45,7 +45,7 @@ import org.pgpainless.key.TestKeys;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
 import org.pgpainless.key.util.KeyRingUtils;
@@ -224,7 +224,7 @@ public class KeyRingInfoTest {
 
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(
-                        KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(
                         KeyType.ECDH(EllipticCurve._BRAINPOOLP384R1),
                         KeyFlag.ENCRYPT_STORAGE))
@@ -560,7 +560,7 @@ public class KeyRingInfoTest {
     public void testGetExpirationDateForUse_NoSuchKey() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .addUserId("Alice")
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .build();
 
         KeyRingInfo info = PGPainless.inspectKeyRing(secretKeys);

--- a/pgpainless-core/src/test/java/org/pgpainless/key/info/UserIdRevocationTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/info/UserIdRevocationTest.java
@@ -29,7 +29,7 @@ import org.pgpainless.key.TestKeys;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.key.protection.PasswordBasedSecretKeyRingProtector;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.key.protection.UnprotectedKeysProtector;
@@ -44,7 +44,7 @@ public class UserIdRevocationTest {
                         KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.SIGN_DATA, KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(
-                        KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS))
+                        KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS))
                 .addUserId("primary@key.id")
                 .addUserId("secondary@key.id")
                 .build();
@@ -81,7 +81,7 @@ public class UserIdRevocationTest {
                 .setPrimaryKey(KeySpec.getBuilder(
                         KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.SIGN_DATA, KeyFlag.CERTIFY_OTHER))
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS))
                 .addUserId("primary@key.id")
                 .addUserId("secondary@key.id")
                 .build();

--- a/pgpainless-core/src/test/java/org/pgpainless/key/info/UserIdRevocationTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/info/UserIdRevocationTest.java
@@ -28,7 +28,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.TestKeys;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.key.protection.PasswordBasedSecretKeyRingProtector;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
@@ -41,7 +41,7 @@ public class UserIdRevocationTest {
     public void testRevocationWithoutRevocationAttributes() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(
-                        KeyType.EDDSA(EdDSACurve._Ed25519),
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.SIGN_DATA, KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(
                         KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS))
@@ -79,7 +79,7 @@ public class UserIdRevocationTest {
     public void testRevocationWithRevocationReason() throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, PGPException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(
-                        KeyType.EDDSA(EdDSACurve._Ed25519),
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                         KeyFlag.SIGN_DATA, KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS))
                 .addUserId("primary@key.id")

--- a/pgpainless-core/src/test/java/org/pgpainless/key/modification/AddSubkeyWithModifiedBindingSignatureSubpackets.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/modification/AddSubkeyWithModifiedBindingSignatureSubpackets.java
@@ -29,7 +29,7 @@ import org.pgpainless.key.OpenPgpV4Fingerprint;
 import org.pgpainless.key.generation.KeyRingBuilder;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.info.KeyRingInfo;
 import org.pgpainless.key.protection.SecretKeyRingProtector;
 import org.pgpainless.signature.subpackets.SelfSignatureSubpackets;
@@ -47,7 +47,7 @@ public class AddSubkeyWithModifiedBindingSignatureSubpackets {
         KeyRingInfo before = PGPainless.inspectKeyRing(secretKeys);
 
         PGPKeyPair secretSubkey = KeyRingBuilder.generateKeyPair(
-                KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA).build());
+                KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA).build());
 
         long secondsUntilExpiration = 1000;
         secretKeys = PGPainless.modifyKeyRing(secretKeys)

--- a/pgpainless-core/src/test/java/org/pgpainless/key/modification/RefuseToAddWeakSubkeyTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/key/modification/RefuseToAddWeakSubkeyTest.java
@@ -67,7 +67,7 @@ public class RefuseToAddWeakSubkeyTest {
         minimalBitStrengths.put(PublicKeyAlgorithm.ECDSA, 250);
         // Note: EdDSA is not mentioned in the BSI document.
         //  We assume that the requirements are similar to other EC algorithms.
-        minimalBitStrengths.put(PublicKeyAlgorithm.EDDSA, 250);
+        minimalBitStrengths.put(PublicKeyAlgorithm.EDDSA_LEGACY, 250);
         // §7.2.1
         minimalBitStrengths.put(PublicKeyAlgorithm.DIFFIE_HELLMAN, 2000);
         // §7.2.2

--- a/pgpainless-core/src/test/java/org/pgpainless/signature/OnePassSignatureBracketingTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/signature/OnePassSignatureBracketingTest.java
@@ -144,7 +144,7 @@ public class OnePassSignatureBracketingTest {
             // 4 is hash algo
             assertEquals(HashAlgorithm.SHA512.getAlgorithmId(), encoded[4]);
             // 5 is public key algo
-            assertEquals(PublicKeyAlgorithm.EDDSA.getAlgorithmId(), encoded[5]);
+            assertEquals(PublicKeyAlgorithm.EDDSA_LEGACY.getAlgorithmId(), encoded[5]);
             // [6,7,8,9,10,11,12,13] are key-id
 
             boolean last = i == signatures.size() - 1;

--- a/pgpainless-core/src/test/java/org/pgpainless/util/GuessPreferredHashAlgorithmTest.java
+++ b/pgpainless-core/src/test/java/org/pgpainless/util/GuessPreferredHashAlgorithmTest.java
@@ -21,7 +21,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.algorithm.SymmetricKeyAlgorithm;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.util.OpenPgpKeyAttributeUtil;
 
 public class GuessPreferredHashAlgorithmTest {
@@ -30,7 +30,7 @@ public class GuessPreferredHashAlgorithmTest {
     public void guessPreferredHashAlgorithmsAssumesHashAlgoUsedBySelfSig()
             throws InvalidAlgorithmParameterException, NoSuchAlgorithmException, PGPException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519),
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519),
                                 KeyFlag.CERTIFY_OTHER, KeyFlag.SIGN_DATA)
                         .overridePreferredHashAlgorithms(new HashAlgorithm[] {})
                         .overridePreferredSymmetricKeyAlgorithms(new SymmetricKeyAlgorithm[] {})

--- a/pgpainless-core/src/test/kotlin/org/pgpainless/key/KeyWithoutSelfSigsTest.kt
+++ b/pgpainless-core/src/test/kotlin/org/pgpainless/key/KeyWithoutSelfSigsTest.kt
@@ -19,7 +19,7 @@ import org.pgpainless.encryption_signing.SigningOptions
 import org.pgpainless.key.generation.KeySpec
 import org.pgpainless.key.generation.type.KeyType
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve
-import org.pgpainless.key.generation.type.xdh.XDHSpec
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec
 import org.pgpainless.key.protection.SecretKeyRingProtector
 
 class KeyWithoutSelfSigsTest {
@@ -62,7 +62,7 @@ class KeyWithoutSelfSigsTest {
                         KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(
                     KeySpec.getBuilder(
-                        KeyType.XDH(XDHSpec._X25519),
+                        KeyType.XDH_LEGACY(XDHLegacySpec._X25519),
                         KeyFlag.ENCRYPT_STORAGE,
                         KeyFlag.ENCRYPT_COMMS))
                 .build()

--- a/pgpainless-core/src/test/kotlin/org/pgpainless/key/KeyWithoutSelfSigsTest.kt
+++ b/pgpainless-core/src/test/kotlin/org/pgpainless/key/KeyWithoutSelfSigsTest.kt
@@ -18,7 +18,7 @@ import org.pgpainless.encryption_signing.ProducerOptions
 import org.pgpainless.encryption_signing.SigningOptions
 import org.pgpainless.key.generation.KeySpec
 import org.pgpainless.key.generation.type.KeyType
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve
 import org.pgpainless.key.generation.type.xdh.XDHSpec
 import org.pgpainless.key.protection.SecretKeyRingProtector
 
@@ -56,9 +56,10 @@ class KeyWithoutSelfSigsTest {
     fun generateKey() {
         val key =
             PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519)))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519)))
                 .addSubkey(
-                    KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA))
+                    KeySpec.getBuilder(
+                        KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(
                     KeySpec.getBuilder(
                         KeyType.XDH(XDHSpec._X25519),

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/GenerateKeyImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/GenerateKeyImpl.java
@@ -23,7 +23,7 @@ import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.util.ArmorUtils;
 import org.pgpainless.util.Passphrase;
 import sop.Profile;
@@ -126,7 +126,7 @@ public class GenerateKeyImpl implements GenerateKey {
                     .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                     .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA));
             if (!signingOnly) {
-                keyBuilder.addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE));
+                keyBuilder.addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE));
             }
         }
         // RSA 4096

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/GenerateKeyImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/GenerateKeyImpl.java
@@ -21,7 +21,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.KeyRingBuilder;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.rsa.RsaLength;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.util.ArmorUtils;
@@ -123,8 +123,8 @@ public class GenerateKeyImpl implements GenerateKey {
         // XDH + EdDSA
         if (profile.equals(CURVE25519_PROFILE.getName())) {
             keyBuilder = PGPainless.buildKeyRing()
-                    .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
-                    .addSubkey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA));
+                    .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                    .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA));
             if (!signingOnly) {
                 keyBuilder.addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE));
             }

--- a/pgpainless-sop/src/test/java/org/pgpainless/sop/IncapableKeysTest.java
+++ b/pgpainless-sop/src/test/java/org/pgpainless/sop/IncapableKeysTest.java
@@ -13,7 +13,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.ecc.EllipticCurve;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.util.ArmorUtils;
 import sop.SOP;
 import sop.exception.SOPGPException;
@@ -38,15 +38,15 @@ public class IncapableKeysTest {
     public static void generateKeys() throws PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException, IOException {
         PGPSecretKeyRing key = PGPainless.buildKeyRing()
                 .addSubkey(KeySpec.getBuilder(KeyType.ECDH(EllipticCurve._P256), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addUserId("Non Signing <non@signing.key>")
                 .build();
         nonSigningKey = ArmorUtils.toAsciiArmoredString(key).getBytes(StandardCharsets.UTF_8);
         nonSigningCert = sop.extractCert().key(nonSigningKey).getBytes();
 
         key = PGPainless.buildKeyRing()
-                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA))
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addUserId("Non Encryption <non@encryption.key>")
                 .build();
         nonEncryptionKey = ArmorUtils.toAsciiArmoredString(key).getBytes(StandardCharsets.UTF_8);

--- a/pgpainless-sop/src/test/java/sop/testsuite/pgpainless/operation/PGPainlessChangeKeyPasswordTest.java
+++ b/pgpainless-sop/src/test/java/sop/testsuite/pgpainless/operation/PGPainlessChangeKeyPasswordTest.java
@@ -13,7 +13,7 @@ import org.pgpainless.PGPainless;
 import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
-import org.pgpainless.key.generation.type.eddsa.EdDSACurve;
+import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
 import org.pgpainless.key.generation.type.xdh.XDHSpec;
 import org.pgpainless.util.Passphrase;
 import sop.SOP;
@@ -34,8 +34,8 @@ public class PGPainlessChangeKeyPasswordTest extends ChangeKeyPasswordTest {
     @MethodSource("provideInstances")
     public void changePasswordOfKeyWithSeparateSubkeyPasswords(SOP sop) throws IOException, PGPException, InvalidAlgorithmParameterException, NoSuchAlgorithmException {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
-                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.CERTIFY_OTHER))
-                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA(EdDSACurve._Ed25519), KeyFlag.SIGN_DATA))
+                .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
+                .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
                 .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .build();
         Iterator<PGPPublicKey> keys = secretKeys.getPublicKeys();

--- a/pgpainless-sop/src/test/java/sop/testsuite/pgpainless/operation/PGPainlessChangeKeyPasswordTest.java
+++ b/pgpainless-sop/src/test/java/sop/testsuite/pgpainless/operation/PGPainlessChangeKeyPasswordTest.java
@@ -14,7 +14,7 @@ import org.pgpainless.algorithm.KeyFlag;
 import org.pgpainless.key.generation.KeySpec;
 import org.pgpainless.key.generation.type.KeyType;
 import org.pgpainless.key.generation.type.eddsa_legacy.EdDSALegacyCurve;
-import org.pgpainless.key.generation.type.xdh.XDHSpec;
+import org.pgpainless.key.generation.type.xdh_legacy.XDHLegacySpec;
 import org.pgpainless.util.Passphrase;
 import sop.SOP;
 import sop.testsuite.TestData;
@@ -36,7 +36,7 @@ public class PGPainlessChangeKeyPasswordTest extends ChangeKeyPasswordTest {
         PGPSecretKeyRing secretKeys = PGPainless.buildKeyRing()
                 .setPrimaryKey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.CERTIFY_OTHER))
                 .addSubkey(KeySpec.getBuilder(KeyType.EDDSA_LEGACY(EdDSALegacyCurve._Ed25519), KeyFlag.SIGN_DATA))
-                .addSubkey(KeySpec.getBuilder(KeyType.XDH(XDHSpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
+                .addSubkey(KeySpec.getBuilder(KeyType.XDH_LEGACY(XDHLegacySpec._X25519), KeyFlag.ENCRYPT_COMMS, KeyFlag.ENCRYPT_STORAGE))
                 .build();
         Iterator<PGPPublicKey> keys = secretKeys.getPublicKeys();
         long primaryKeyId = keys.next().getKeyID();


### PR DESCRIPTION
The crypto-refresh document introduces eddsa using ed25519 and ed448 as new public key algorithm tags.
The old method of doing eddsa with ed25519 is renamed to eddsa_legacy.

This PR prepares the codebase by renaming the legacy eddsa related classes in preparation for a release that re-introduces them using the new meaning.
Note: This is a breaking change, so only merge for the upcoming major 2.0 release.

The PR further renames XDH related classes to XDHLegacy.