### PR TITLE
Fix OOM error in SOP DetachedSignImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ SPDX-License-Identifier: CC0-1.0
 
 # PGPainless Changelog
 
+## 1.6.7-SNAPSHOT
+- Fix OOM error when detached-signing large amounts of data (fix #432)
+
 ## 1.6.6
 - Downgrade `logback-core` and `logback-classic` to `1.2.13` to fix #426
 

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/DetachedSignImpl.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/DetachedSignImpl.java
@@ -4,7 +4,6 @@
 
 package org.pgpainless.sop;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -92,10 +91,10 @@ public class DetachedSignImpl implements DetachedSign {
             }
         }
 
-        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        OutputStream sink = new NullOutputStream();
         try {
             EncryptionStream signingStream = PGPainless.encryptAndOrSign()
-                    .onOutputStream(buffer)
+                    .onOutputStream(sink)
                     .withOptions(ProducerOptions.sign(signingOptions)
                             .setAsciiArmor(armor));
 

--- a/pgpainless-sop/src/main/java/org/pgpainless/sop/NullOutputStream.java
+++ b/pgpainless-sop/src/main/java/org/pgpainless/sop/NullOutputStream.java
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2024 Paul Schaub <vanitasvitae@fsfe.org>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package org.pgpainless.sop;
+
+import java.io.OutputStream;
+
+/**
+ * {@link OutputStream} that simply discards bytes written to it.
+ */
+public class NullOutputStream extends OutputStream {
+    @Override
+    public void write(int b) {
+        // NOP
+    }
+}


### PR DESCRIPTION
The implementation of the detached signing operation was using a `ByteArrayOutputStream` to unnecessarily cache the (unmodified) plaintext data.
This caused OOM exceptions when signing large amounts of data (see #432 ).

This patch replaces the unnecessary buffer with a sink that simply discards the plaintext data after passing through the signer stream.